### PR TITLE
#18 When classes & property names use reserve names, RDF names get messed up too

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
@@ -41,14 +41,14 @@ endif)
 
 [query public resourceTypeLocalName(aResource: Resource) : String =
 (if (aResource.describes.oclIsUndefined()) then
-    '"'.concat(aResource.javaName(true)).concat('"')
+    '"'.concat(aResource.name).concat('"')
 else
-	'"'.concat(aResource.describes.javaName(true)).concat('"')
+	'"'.concat(aResource.describes.name).concat('"')
 endif)
 /]
 
 [template public generateResourceConstants(aResource : Resource)]
-public static String [resourcePathConstantName(aResource)/] = "[aResource.javaName(false)/]";
+public static String [resourcePathConstantName(aResource)/] = "[aResource.name.toLowerFirst()/]";
 public static String [resourceTypeNamespaceConstantName(aResource)/] = [resourceTypeNamespace(aResource)/]; //namespace of the rdfs:class the resource describes
 public static String [resourceTypeLocalNameConstantName(aResource)/] = [resourceTypeLocalName(aResource)/]; //localName of the rdfs:class the resource describes
 public static String [resourceTypeConstantName(aResource)/] = [resourceTypeNamespaceConstantName(aResource)/] + [resourceTypeLocalNameConstantName(aResource)/]; //fullname of the rdfs:class the resource describes

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
@@ -47,9 +47,9 @@ endif)
 
 [query public resourcePropertyDefinitionLocalName(aResourceProperty: ResourceProperty) : String =
 (if (aResourceProperty.propertyDefinition.oclIsUndefined()) then
-    '"'.concat(aResourceProperty.javaName(false)).concat('"')
+    '"'.concat(aResourceProperty.name).concat('"')
 else
-	'"'.concat(aResourceProperty.propertyDefinition.javaName(false)).concat('"')
+	'"'.concat(aResourceProperty.propertyDefinition.name).concat('"')
 endif)
 /]
 


### PR DESCRIPTION
Solves issue #18: When classes & property names use reserve names, RDF names get messed up too

RDF names are exactly as they are specified in the model (including
capitalisation).

Fixed for both classes and properties.