### PR TITLE
closes #24: Ambiguous methods created for the Creation Factory in the Mgr class

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
@@ -177,7 +177,6 @@ public class [javaClassNameForAdaptorManager(anAdaptorInterface) /] {
     [/for]
 
     [for (aCreationDialog: Dialog | aService.creationDialogs)]
-    [if (aService.creationFactories->select(f: CreationFactory | f.resourceTypes = aCreationDialog.resourceTypes)->isEmpty())]
     public static [creationMethodResourceType(aCreationDialog)/] [creationMethodName(aCreationDialog)/](HttpServletRequest httpServletRequest, final [creationMethodResourceType(aCreationDialog)/] aResource[commaSeparate(dialogMethodSignature(aCreationDialog, false, false), true, false)/])
     {
         [creationMethodResourceType(aCreationDialog)/] newResource = null;
@@ -187,7 +186,6 @@ public class [javaClassNameForAdaptorManager(anAdaptorInterface) /] {
         // [/protected]
         return newResource;
     }
-    [/if]
     [/for]
 
     [for (aBasicCapability: BasicCapability | aService.basicCapabilities)]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -23,7 +23,6 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::serviceProviderServices/]
-[import org::eclipse::lyo::oslc4j::codegenerator::services::serviceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
 
 [comment TODO: we should avoid relying on "eContainer", since objects that come from a composing emf file, will not have the eContainer relationship setup as expected.
@@ -59,20 +58,45 @@ anAdaptorInterface.serviceProviders()->select(aServiceProvider : ServiceProvider
             )->asSet()
 /]
 
+[comment return the set of QueryCapabilities whose managed resources is the same as "resources", without any consideration for order./]
+[query public queryCapabilities(anAdaptorInterface : AdaptorInterface, resources: Bag(Resource)) : Sequence(QueryCapability) = 
+anAdaptorInterface.serviceProviders().services.queryCapabilities->select(aQueryCapability : QueryCapability | aQueryCapability.resourceTypes->asBag() = resources)
+/]
+
 [query public queryCapabilities(anAdaptorInterface : AdaptorInterface, aResource: Resource) : Sequence(QueryCapability) = 
 anAdaptorInterface.serviceProviders().services.queryCapabilities->select(aQueryCapability : QueryCapability | aQueryCapability.resourceTypes->includes(aResource))
+/]
+
+[comment return the set of BasicCapabilities whose managed resources is the same as "resources", without any consideration for order./]
+[query public basicCapabilities(anAdaptorInterface : AdaptorInterface, resources: Bag(Resource)) : Sequence(BasicCapability) = 
+anAdaptorInterface.serviceProviders().services.basicCapabilities->select(aBasicCapability : BasicCapability | aBasicCapability.resourceTypes->asBag() = resources)
 /]
 
 [query public basicCapabilities(anAdaptorInterface : AdaptorInterface, aResource: Resource) : Sequence(BasicCapability) = 
 anAdaptorInterface.serviceProviders().services.basicCapabilities->select(aBasicCapability : BasicCapability | aBasicCapability.resourceTypes->includes(aResource))
 /]
 
+[comment return the set of CreationFactories whose managed resources is the same as "resources", without any consideration for order./]
+[query public creationFactories(anAdaptorInterface : AdaptorInterface, resources: Bag(Resource)) : Sequence(CreationFactory) = 
+anAdaptorInterface.serviceProviders().services.creationFactories->select(aCreationFactory : CreationFactory | aCreationFactory.resourceTypes->asBag() = resources)
+/]
+
 [query public creationFactories(anAdaptorInterface : AdaptorInterface, aResource: Resource) : Sequence(CreationFactory) = 
 anAdaptorInterface.serviceProviders().services.creationFactories->select(aCreationFactory : CreationFactory | aCreationFactory.resourceTypes->includes(aResource))
 /]
 
+[comment return the set of SelectionDialogs whose managed resources is the same as "resources", without any consideration for order./]
+[query public selectionDialogs(anAdaptorInterface : AdaptorInterface, resources: Bag(Resource)) : Sequence(Dialog) = 
+anAdaptorInterface.serviceProviders().services.selectionDialogs->select(aDialog : Dialog | aDialog.resourceTypes->asBag() = resources)
+/]
+
 [query public selectionDialogs(anAdaptorInterface : AdaptorInterface, aResource: Resource) : Sequence(Dialog) = 
 anAdaptorInterface.serviceProviders().services.selectionDialogs->select(aDialog : Dialog | aDialog.resourceTypes->includes(aResource))
+/]
+
+[comment return the set of CreationDialogs whose managed resources is the same as "resources", without any consideration for order./]
+[query public creationDialogs(anAdaptorInterface : AdaptorInterface, resources: Bag(Resource)) : Sequence(Dialog) = 
+anAdaptorInterface.serviceProviders().services.creationDialogs->select(aDialog : Dialog | aDialog.resourceTypes->asBag() = resources)
 /]
 
 [query public creationDialogs(anAdaptorInterface : AdaptorInterface, aResource: Resource) : Sequence(Dialog) = 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/serviceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/serviceServices.mtl
@@ -22,6 +22,7 @@
 
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourceServices/]
+[import org::eclipse::lyo::oslc4j::codegenerator::services::adaptorInterfaceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::serviceProviderServices/]
 
 [query public containingAdaptorInterface(aService: Service) : AdaptorInterface =
@@ -126,6 +127,13 @@ JAXRSPathParameters(aQueryCapability.URI())
 [query public queryMethodName(aQueryCapability: QueryCapability, forRDF : Boolean) : String = 
 concatenate(aQueryCapability.resourceTypes.javaName(true)->sep('query', 'sAnd', 's').oclAsType(String))
 	.concat((if forRDF then '' else 'AsHtml' endif))
+	.concat(
+		(if (queryCapabilities(aQueryCapability.containingAdaptorInterface(), aQueryCapability.resourceTypes->asBag())->size() > 1) then 
+			 'For'.concat(javaString(aQueryCapability.title, '', true))
+		else 
+			'' 
+		endif)
+	)
 /]
 
 [query public queryMethodResourceType(aQueryCapability: QueryCapability) : String = 
@@ -171,7 +179,13 @@ JAXRSPathParameters(aCreationFactory.URI())
 
 [query public creationMethodName(aCreationFactory: CreationFactory) : String = 
 concatenate(aCreationFactory.resourceTypes.javaName(true)->sep('create', 'And', '').oclAsType(String))
-.concat('')
+.concat(
+	(if (creationFactories(aCreationFactory.containingAdaptorInterface(), aCreationFactory.resourceTypes->asBag())->size() > 1) then 
+		 'For'.concat(javaString(aCreationFactory.title, '', true))
+	else 
+		'' 
+	endif)
+)
 /]
 
 [query public creationMethodResourceType(aCreationFactory: CreationFactory) : String = 
@@ -223,6 +237,15 @@ JAXRSPathParameters(aDialog.URI(selectionDialog))
 [query public dialogMethodName(aDialog: Dialog, selectionDialog : Boolean) : String = 
 concatenate(aDialog.resourceTypes.javaName(true)->sep('', 'And', '').oclAsType(String))
 	.concat((if selectionDialog then 'Selector' else 'Creator' endif))
+	.concat(
+		(if ((selectionDialog) and (selectionDialogs(aDialog.containingAdaptorInterface(), aDialog.resourceTypes->asBag())->size() > 1))
+			or ((not selectionDialog) and (creationDialogs(aDialog.containingAdaptorInterface(), aDialog.resourceTypes->asBag())->size() > 1))
+ 		then 
+			 'For'.concat(javaString(aDialog.title, '', true))
+		else 
+			'' 
+		endif)
+	)
 /]
 
 [query public dialogMethodResourceType(aDialog: Dialog) : String = 
@@ -247,7 +270,14 @@ methodParameterList(JAXRSPathParameters(aDialog.URI(selectionDialog)))
 
 [query public creationMethodName(aCreationDialog: Dialog) : String = 
 concatenate(aCreationDialog.resourceTypes.javaName(true)->sep('create', 'And', '').oclAsType(String))
-.concat('')
+.concat('FromDialog')
+.concat(
+	(if (creationDialogs(aCreationDialog.containingAdaptorInterface(), aCreationDialog.resourceTypes->asBag())->size() > 1) then 
+		 'For'.concat(javaString(aCreationDialog.title, '', true))
+	else 
+		'' 
+	endif)
+)
 /]
 
 [query public creationMethodResourceType(aCreationDialog: Dialog) : String = 


### PR DESCRIPTION
closes #24: Ambiguous methods created for the Creation Factory in the Mgr class

The problem occur when there are 1+ capabilities (such as
CreationFactory) within an adaptor that manage the same (set of)
resources. This results in multiple methods in the AdaptorManager that
have the same signature.
To remedy, for such 1+ capabilities, append the name of the capability
to the method. For example, a creation factory - with title CF1 - on
Requirement will result in method called "createRequirementForCF1"

This change also made it necessary to have a additional method in
AdaptorManager to handle the creation method from a CreationDialog
(previously, both CreationDialog and CreationFactory) shared the same
createResource method in Manager.