### PR TITLE
closes #18: When classes & property names use reserve names, RDF names

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
@@ -48,7 +48,7 @@ endif)
 /]
 
 [template public generateResourceConstants(aResource : Resource)]
-public static String [resourcePathConstantName(aResource)/] = "[aResource.name.toLowerFirst()/]";
+public static String [resourcePathConstantName(aResource)/] = "[javaString(aResource.name, '', false)/]";
 public static String [resourceTypeNamespaceConstantName(aResource)/] = [resourceTypeNamespace(aResource)/]; //namespace of the rdfs:class the resource describes
 public static String [resourceTypeLocalNameConstantName(aResource)/] = [resourceTypeLocalName(aResource)/]; //localName of the rdfs:class the resource describes
 public static String [resourceTypeConstantName(aResource)/] = [resourceTypeNamespaceConstantName(aResource)/] + [resourceTypeLocalNameConstantName(aResource)/]; //fullname of the rdfs:class the resource describes


### PR DESCRIPTION
closes #18: When classes & property names use reserve names, RDF names get messed up too

the relative path for a particular resource no longer has invalid characters such as empty space.