### PR TITLE
Code generate (optional) swagger documentation

### DIFF
--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -18,6 +18,7 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="javascriptFilesBasePath"
         lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="swaggerDocumentation" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="backendCodeTemplate_classImports"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="backendCodeTemplate_classMethods"

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -63,6 +63,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/javaFilesBasePath"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/jspFilesBasePath"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/javascriptFilesBasePath"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/swaggerSupport"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_classImports"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_classMethods"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_servletListenerInitialize"/>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorApplication.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorApplication.mtl
@@ -132,6 +132,12 @@ public class [javaClassNameForAdaptorApplication(anAdaptorInterface) /] extends 
         RESOURCE_CLASSES.add([javaClassNameForService(aServiceProvider)/].class);
         [/for]
         RESOURCE_CLASSES.add([javaClassNameForResourceShapeService(anAdaptorInterface)/].class);
+        [if (anAdaptorInterface.swaggerDocumentationEnabled())]
+
+        // Swagger resources
+        RESOURCE_CLASSES.add(io.swagger.jaxrs.listing.ApiListingResource.class);
+        RESOURCE_CLASSES.add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+        [/if]
 
         // [protected ('Custom Resource Classes')]
         // [/protected]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
@@ -33,6 +33,50 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::jsp::generateGetResourceJsp/]
 
+[template public swaggerImportPackages(anAdaptorInterface: AdaptorInterface)]
+[if (anAdaptorInterface.swaggerDocumentationEnabled())]
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+[/if]
+[/template]
+
+[template public swaggerAnnotation(aService: Service, anAdaptorInterface: AdaptorInterface)]
+[if (anAdaptorInterface.swaggerDocumentationEnabled())]
+@Api(value = "OSLC Service for {" + [for (aResource: Resource | aService.servicedResources()->sortedBy(name)) separator(' + ", " + ') ][javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourceTypeLocalNameConstantName(aResource) /][/for] + "}")
+[/if]
+[/template]
+
+
+[template public swaggerApiOperationAnnotation(capability: String, resources: Set(Resource), produces: String, anAdaptorInterface: AdaptorInterface)]
+[if (anAdaptorInterface.swaggerDocumentationEnabled())]
+@ApiOperation(
+    value = "[capability/] for resources of type {" + [for (aResource: Resource | resources->sortedBy(name)) separator(' + ", " + ') ][javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourceTypeLocalNameConstantName(aResource)/][/for] + "}",
+    notes = "[capability/] for resources of type {" + [for (aResource: Resource | resources->sortedBy(name)) separator(' + ", " + ') ]"<a href=\"" + [javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourceTypeConstantName(aResource)/] + "\">" + [javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourceTypeLocalNameConstantName(aResource)/] + "</a>"[/for] + "}" +
+        ", with respective resource shapes {" + [for (aResource: Resource | resources->sortedBy(name)) separator(' + ", " + ') ]"<a href=\"" + "../services/" + OslcConstants.PATH_RESOURCE_SHAPES + "/" + [javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourcePathConstantName(aResource)/] + "\">" + [javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourceTypeLocalNameConstantName(aResource)/] + "</a>"[/for] + "}",
+    produces = [produces/]
+)
+[/if]
+[/template]
+
+
+[template public swaggerApiOperationAnnotation(aQueryCapability: QueryCapability, anAdaptorInterface: AdaptorInterface)]
+[swaggerApiOperationAnnotation('Query capability', aQueryCapability.resourceTypes, 
+    'OslcMediaType.APPLICATION_RDF_XML + ", " + OslcMediaType.APPLICATION_XML + ", " + OslcMediaType.APPLICATION_JSON + ", " + OslcMediaType.TEXT_TURTLE + ", " + MediaType.TEXT_HTML', 
+    anAdaptorInterface)/]
+[/template]
+
+[template public swaggerApiOperationAnnotation(aCreationFactory: CreationFactory, anAdaptorInterface: AdaptorInterface)]
+[swaggerApiOperationAnnotation('Creation factory', aCreationFactory.resourceTypes, 
+    'OslcMediaType.APPLICATION_RDF_XML + ", " + OslcMediaType.APPLICATION_XML + ", " + OslcMediaType.APPLICATION_JSON + ", " + OslcMediaType.TEXT_TURTLE', 
+    anAdaptorInterface)/]
+[/template]
+
+[template public swaggerApiOperationAnnotation(aBasicCapability: BasicCapability, aResource: Resource, method: String, anAdaptorInterface: AdaptorInterface)]
+[swaggerApiOperationAnnotation(method, Set {aResource}, 
+    'OslcMediaType.APPLICATION_RDF_XML + ", " + OslcMediaType.APPLICATION_XML + ", " + OslcMediaType.APPLICATION_JSON + ", " + OslcMediaType.TEXT_TURTLE + ", " + MediaType.TEXT_HTML + ", " + OslcMediaType.APPLICATION_X_OSLC_COMPACT_XML', 
+    anAdaptorInterface)/]
+[/template]
+
 [template public generateResourceService(aService : Service)]
 [file (javaClassFullFileName(aService), false, 'UTF-8')]
 [let anAdaptorInterface: AdaptorInterface = containingAdaptorInterface(aService)]
@@ -119,7 +163,8 @@ import [javaClassFullNameForSingleton(anAdaptorInterface.serviceProviderCatalog)
 [for (aResource: Resource | aService.relevantResources()->sortedBy(name))]
 import [javaClassFullName(aResource, anAdaptorInterface, null) /];
 [/for]
-
+[anAdaptorInterface.swaggerImportPackages()
+/]
 // [protected ('imports')]
 // [/protected]
 
@@ -127,7 +172,8 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
 // [/protected]
 @OslcService([javaInterfaceNameForConstants(aService.domainSpecification)/].[domainSpecificationConstantName(aService.domainSpecification)/])
 [JAXRSPathAnnotation(aService.serviceBaseURI()) /]
-public class [javaClassName(aService) /]
+[aService.swaggerAnnotation(anAdaptorInterface)
+/]public class [javaClassName(aService) /]
 {
     @Context private HttpServletRequest httpServletRequest;
     @Context private HttpServletResponse httpServletResponse;
@@ -156,7 +202,8 @@ public class [javaClassName(aService) /]
     @GET
     [JAXRSPathAnnotation(aQueryCapability.URISegment())/]
     @Produces({OslcMediaType.APPLICATION_RDF_XML, OslcMediaType.APPLICATION_XML, OslcMediaType.APPLICATION_JSON, OslcMediaType.TEXT_TURTLE})
-    public [queryMethodReturnType(aQueryCapability, true)/] [queryMethodName(aQueryCapability, true)/](
+    [aQueryCapability.swaggerApiOperationAnnotation(anAdaptorInterface)
+    /]public [queryMethodReturnType(aQueryCapability, true)/] [queryMethodName(aQueryCapability, true)/](
                                                     [commaSeparate(queryMethodSignature(aQueryCapability, true), false, true) /]
                                                      @QueryParam("oslc.where") final String where,
                                                      @QueryParam("page") final String pageString,
@@ -182,7 +229,8 @@ public class [javaClassName(aService) /]
     @GET
     [JAXRSPathAnnotation(aQueryCapability.URISegment()) /]
     @Produces({ MediaType.TEXT_HTML })
-    public [queryMethodReturnType(aQueryCapability, false)/] [queryMethodName(aQueryCapability, false)/](
+    [aQueryCapability.swaggerApiOperationAnnotation(anAdaptorInterface)
+    /]public [queryMethodReturnType(aQueryCapability, false)/] [queryMethodName(aQueryCapability, false)/](
                                     [commaSeparate(queryMethodSignature(aQueryCapability, true), false, true)/]
                                        @QueryParam("oslc.where") final String where,
                                        @QueryParam("page") final String pageString,
@@ -293,7 +341,8 @@ public class [javaClassName(aService) /]
     [JAXRSPathAnnotation(aCreationFactory.URISegment()) /]
     @Consumes({OslcMediaType.APPLICATION_RDF_XML, OslcMediaType.APPLICATION_XML, OslcMediaType.APPLICATION_JSON, OslcMediaType.TEXT_TURTLE})
     @Produces({OslcMediaType.APPLICATION_RDF_XML, OslcMediaType.APPLICATION_XML, OslcMediaType.APPLICATION_JSON, OslcMediaType.TEXT_TURTLE})
-    public [creationMethodReturnType(aCreationFactory)/] [creationMethodName(aCreationFactory)/](
+    [aCreationFactory.swaggerApiOperationAnnotation(anAdaptorInterface)
+    /]public [creationMethodReturnType(aCreationFactory)/] [creationMethodName(aCreationFactory)/](
             [commaSeparate(creationMethodSignature(aCreationFactory, true), false, true)/]
             final [creationMethodResourceType(aCreationFactory)/] aResource
         ) throws IOException, ServletException
@@ -429,7 +478,8 @@ public class [javaClassName(aService) /]
     @GET
     [JAXRSPathAnnotation(aResource.instanceURISegment(aBasicCapability))/]
     @Produces({OslcMediaType.APPLICATION_RDF_XML, OslcMediaType.APPLICATION_XML, OslcMediaType.APPLICATION_JSON, OslcMediaType.TEXT_TURTLE})
-    public [getResourceMethodReturnType(aBasicCapability, aResource, true)/] [getResourceMethodName(aBasicCapability, aResource, true)/](
+    [aBasicCapability.swaggerApiOperationAnnotation(aResource, 'GET', anAdaptorInterface)
+    /]public [getResourceMethodReturnType(aBasicCapability, aResource, true)/] [getResourceMethodName(aBasicCapability, aResource, true)/](
                 [commaSeparate(instanceMethodSignature(aResource, aBasicCapability, true), false, false)/]
         ) throws IOException, ServletException, URISyntaxException
     {
@@ -451,7 +501,8 @@ public class [javaClassName(aService) /]
     @GET
     [JAXRSPathAnnotation(aResource.instanceURISegment(aBasicCapability))/]
     @Produces({ MediaType.TEXT_HTML })
-    public [getResourceMethodReturnType(aBasicCapability, aResource, false)/] [getResourceMethodName(aBasicCapability, aResource, false)/](
+    [aBasicCapability.swaggerApiOperationAnnotation(aResource, 'GET', anAdaptorInterface)
+    /]public [getResourceMethodReturnType(aBasicCapability, aResource, false)/] [getResourceMethodName(aBasicCapability, aResource, false)/](
         [commaSeparate(instanceMethodSignature(aResource, aBasicCapability, true), false, false)/]
         ) throws ServletException, IOException, URISyntaxException
     {
@@ -475,7 +526,8 @@ public class [javaClassName(aService) /]
     @GET
     [JAXRSPathAnnotation(aResource.instanceURISegment(aBasicCapability))/]
     @Produces({OslcMediaType.APPLICATION_X_OSLC_COMPACT_XML})
-    public Compact [getResourceCompactMethodName(aBasicCapability, aResource)/](
+    [aBasicCapability.swaggerApiOperationAnnotation(aResource, 'GET', anAdaptorInterface)
+    /]public Compact [getResourceCompactMethodName(aBasicCapability, aResource)/](
         [commaSeparate(instanceMethodSignature(aResource, aBasicCapability, true), false, false)/]
         ) throws ServletException, IOException, URISyntaxException
     {
@@ -573,7 +625,8 @@ public class [javaClassName(aService) /]
     [for (aResource: Resource | aBasicCapability.resourceTypes)]
     @DELETE
     [JAXRSPathAnnotation(aResource.instanceURISegment(aBasicCapability))/]
-    public [deleteResourceMethodReturnType(aBasicCapability, aResource)/] [deleteResourceMethodName(aBasicCapability, aResource)/](
+    [aBasicCapability.swaggerApiOperationAnnotation(aResource, 'DELETE', anAdaptorInterface)
+    /]public [deleteResourceMethodReturnType(aBasicCapability, aResource)/] [deleteResourceMethodName(aBasicCapability, aResource)/](
                 [commaSeparate(instanceMethodSignature(aResource, aBasicCapability, true), false, false)/]
         ) throws IOException, ServletException, URISyntaxException
     {
@@ -600,7 +653,8 @@ public class [javaClassName(aService) /]
     @PUT
     [JAXRSPathAnnotation(aResource.instanceURISegment(aBasicCapability))/]
     @Consumes({OslcMediaType.APPLICATION_RDF_XML, OslcMediaType.APPLICATION_XML, OslcMediaType.APPLICATION_JSON, OslcMediaType.TEXT_TURTLE})
-    public [updateResourceMethodReturnType(aBasicCapability, aResource)/] [updateResourceMethodName(aBasicCapability, aResource)/](
+    [aBasicCapability.swaggerApiOperationAnnotation(aResource, 'PUT', anAdaptorInterface)
+    /]public [updateResourceMethodReturnType(aBasicCapability, aResource)/] [updateResourceMethodName(aBasicCapability, aResource)/](
             @HeaderParam("If-Match") final String eTagHeader,
             [commaSeparate(instanceMethodSignature(aResource, aBasicCapability, true), false, true)/]
             final [getResourceMethodResourceType(aBasicCapability, aResource)/] aResource

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateIndexJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateIndexJsp.mtl
@@ -24,6 +24,18 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::jspServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::adaptorInterfaceServices/]
 
+[template public swaggerDocumentation(anAdaptorInterface : AdaptorInterface)]
+[if (anAdaptorInterface.swaggerDocumentationEnabled())]
+<p class="lead">
+    <a class="btn btn-primary btn-lg" href="<%= UriBuilder.fromUri(OSLC4JUtils.getPublicURI()).path("/swagger-ui").build() %>" role="button">Interactive API console</a>
+</p>
+<p>Use <a href="<%= "https://swagger.io/swagger-ui/" %>">Swagger UI</a> To interact with the adaptor services dedicated for RDF.
+</p>
+<p>You can also copy <a href="<%= UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("/swagger.yaml").build() %>">this OpenAPI specification document (yaml file) of this adaptor</a> to a <a href="<%= "https://editor.swagger.io" %>">Swagger Editor</a> to generate client SDK code for a number of languages and platforms.
+</p>
+[/if]
+[/template]
+
 [template public generateIndexJsp(anAdaptorInterface : AdaptorInterface)]
 [file (jspFilesBasePath(anAdaptorInterface).concatenatePaths('index.jsp'), false, 'UTF-8')]
 <!DOCTYPE html>
@@ -77,18 +89,30 @@ To revert to the default generated content, delete all content in this file, and
 </head>
 <body>
 <div class="container">
-
     <div class="jumbotron">
         <h1 class="display-3">Adaptor home!</h1>
         <p class="lead">This is a homepage of the <em>[anAdaptorInterface.name/]</em> that was generated using
             Eclipse Lyo Toolchain Designer.</p>
         <hr class="my-4">
-        <p>In order to begin exploring it, start from the Service Provider Catalog to see the
-            available Service Providers
-            .</p>
         <p class="lead">
             <a class="btn btn-primary btn-lg" href="<%= UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("/catalog/singleton").build() %>" role="button">Service Provider
                 Catalog</a>
+        </p>
+        <p>Start from the Service Provider Catalog, to navigate your adaptor's services and resources, using the available Query capabilities, Selection and Creation Dialogs. 
+            Note that these are end-user HTML pages, which is very useful for debugging your adaptor.</p>
+        [swaggerDocumentation(anAdaptorInterface)/]
+    </div>
+    <div class="alert alert-primary" role="alert">
+        <h4 class="alert-heading">Sample front page!</h4>
+        <hr>
+        <p>This initially generated sample front page can be modified, by changing the file <code>[jspFilesBasePath(anAdaptorInterface).concatenatePaths('index.jsp')/]</code></p>
+        <ul>
+        <li>Any changes made will not be overriden upon future re-generations.</li>
+        <li>If you need to revert to the originally generated content, delete the file and/or its complete content.</li>
+        </ul>
+        <p><strong>You enabled Swagger Documentation?</strong>
+            If you have enabled Swagger Documentation in the generated code, make sure you have configured your project according to these 
+            <a href="<%= "https://wiki.eclipse.org/Lyo/creating_OSLC4J_project#OpenApi.2FSwagger_Support_.28Optional.29" %>">Lyo Instructions for Swagger</a>
         </p>
     </div>
 </div>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -36,6 +36,14 @@ else
 endif)
 /]
 
+[query public swaggerDocumentationEnabled(anAdaptorInterface : AdaptorInterface) : Boolean = 
+(if anAdaptorInterface.swaggerDocumentation.oclIsUndefined() then
+    false
+else
+    anAdaptorInterface.swaggerDocumentation
+endif)
+/]
+
 [query public javaName(anAdaptorInterface : AdaptorInterface, toUpperFirst : Boolean) : String = 
 javaString(anAdaptorInterface.name, 'oslc', toUpperFirst)
 /]

--- a/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
@@ -177,3 +177,5 @@ _UI_ShaclPropertyDataType_URI_literal = URI
 _UI_ShaclPropertyDataType_Double_literal = Double
 _UI_ShaclPropertyDataType_Float_literal = Float
 _UI_ShaclPropertyDataType_Integer_literal = Integer
+_UI_AdaptorInterface_swaggerSupport_feature = Swagger Support
+_UI_AdaptorInterface_swaggerDocumentation_feature = Swagger Documentation

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/AdaptorInterfaceItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/AdaptorInterfaceItemProvider.java
@@ -68,6 +68,7 @@ public class AdaptorInterfaceItemProvider
 			addJavaFilesBasePathPropertyDescriptor(object);
 			addJspFilesBasePathPropertyDescriptor(object);
 			addJavascriptFilesBasePathPropertyDescriptor(object);
+			addSwaggerDocumentationPropertyDescriptor(object);
 			addBackendCodeTemplate_classImportsPropertyDescriptor(object);
 			addBackendCodeTemplate_classMethodsPropertyDescriptor(object);
 			addBackendCodeTemplate_servletListenerInitializePropertyDescriptor(object);
@@ -187,6 +188,28 @@ public class AdaptorInterfaceItemProvider
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Swagger Documentation feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addSwaggerDocumentationPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_AdaptorInterface_swaggerDocumentation_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_AdaptorInterface_swaggerDocumentation_feature", "_UI_AdaptorInterface_type"),
+				 AdaptorinterfacePackage.Literals.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
 				 null,
 				 null));
 	}
@@ -464,6 +487,7 @@ public class AdaptorInterfaceItemProvider
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVA_FILES_BASE_PATH:
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JSP_FILES_BASE_PATH:
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH:
+			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION:
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS:
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS:
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_INITIALIZE:

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorInterface.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorInterface.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link adaptorinterface.AdaptorInterface#getJavaFilesBasePath <em>Java Files Base Path</em>}</li>
  *   <li>{@link adaptorinterface.AdaptorInterface#getJspFilesBasePath <em>Jsp Files Base Path</em>}</li>
  *   <li>{@link adaptorinterface.AdaptorInterface#getJavascriptFilesBasePath <em>Javascript Files Base Path</em>}</li>
+ *   <li>{@link adaptorinterface.AdaptorInterface#isSwaggerDocumentation <em>Swagger Documentation</em>}</li>
  *   <li>{@link adaptorinterface.AdaptorInterface#getBackendCodeTemplate_classImports <em>Backend Code Template class Imports</em>}</li>
  *   <li>{@link adaptorinterface.AdaptorInterface#getBackendCodeTemplate_classMethods <em>Backend Code Template class Methods</em>}</li>
  *   <li>{@link adaptorinterface.AdaptorInterface#getBackendCodeTemplate_servletListenerInitialize <em>Backend Code Template servlet Listener Initialize</em>}</li>
@@ -220,6 +221,32 @@ public interface AdaptorInterface extends EObject {
 	 * @generated
 	 */
 	void setJavascriptFilesBasePath(String value);
+
+	/**
+	 * Returns the value of the '<em><b>Swagger Documentation</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Swagger Documentation</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Swagger Documentation</em>' attribute.
+	 * @see #setSwaggerDocumentation(boolean)
+	 * @see adaptorinterface.AdaptorinterfacePackage#getAdaptorInterface_SwaggerDocumentation()
+	 * @model
+	 * @generated
+	 */
+	boolean isSwaggerDocumentation();
+
+	/**
+	 * Sets the value of the '{@link adaptorinterface.AdaptorInterface#isSwaggerDocumentation <em>Swagger Documentation</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Swagger Documentation</em>' attribute.
+	 * @see #isSwaggerDocumentation()
+	 * @generated
+	 */
+	void setSwaggerDocumentation(boolean value);
 
 	/**
 	 * Returns the value of the '<em><b>Backend Code Template class Imports</b></em>' attribute.

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
@@ -140,13 +140,22 @@ public interface AdaptorinterfacePackage extends EPackage {
 	int ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH = 7;
 
 	/**
+	 * The feature id for the '<em><b>Swagger Documentation</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION = 8;
+
+	/**
 	 * The feature id for the '<em><b>Backend Code Template class Imports</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS = 8;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS = 9;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template class Methods</b></em>' attribute.
@@ -155,7 +164,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS = 9;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS = 10;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template servlet Listener Initialize</b></em>' attribute.
@@ -164,7 +173,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_INITIALIZE = 10;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_INITIALIZE = 11;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template servlet Listener Destroy</b></em>' attribute.
@@ -173,7 +182,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_DESTROY = 11;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_DESTROY = 12;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template get Service Providers</b></em>' attribute.
@@ -182,7 +191,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_SERVICE_PROVIDERS = 12;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_SERVICE_PROVIDERS = 13;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template get Resource</b></em>' attribute.
@@ -191,7 +200,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_RESOURCE = 13;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_RESOURCE = 14;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template get Resources</b></em>' attribute.
@@ -200,7 +209,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_RESOURCES = 14;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_GET_RESOURCES = 15;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template search Resources</b></em>' attribute.
@@ -209,7 +218,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SEARCH_RESOURCES = 15;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SEARCH_RESOURCES = 16;
 
 	/**
 	 * The feature id for the '<em><b>Backend Code Template create Resource</b></em>' attribute.
@@ -218,7 +227,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CREATE_RESOURCE = 16;
+	int ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CREATE_RESOURCE = 17;
 
 	/**
 	 * The number of structural features of the '<em>Adaptor Interface</em>' class.
@@ -227,7 +236,7 @@ public interface AdaptorinterfacePackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int ADAPTOR_INTERFACE_FEATURE_COUNT = 17;
+	int ADAPTOR_INTERFACE_FEATURE_COUNT = 18;
 
 	/**
 	 * The number of operations of the '<em>Adaptor Interface</em>' class.
@@ -1786,6 +1795,17 @@ public interface AdaptorinterfacePackage extends EPackage {
 	EAttribute getAdaptorInterface_JavascriptFilesBasePath();
 
 	/**
+	 * Returns the meta object for the attribute '{@link adaptorinterface.AdaptorInterface#isSwaggerDocumentation <em>Swagger Documentation</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Swagger Documentation</em>'.
+	 * @see adaptorinterface.AdaptorInterface#isSwaggerDocumentation()
+	 * @see #getAdaptorInterface()
+	 * @generated
+	 */
+	EAttribute getAdaptorInterface_SwaggerDocumentation();
+
+	/**
 	 * Returns the meta object for the attribute '{@link adaptorinterface.AdaptorInterface#getBackendCodeTemplate_classImports <em>Backend Code Template class Imports</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -3221,6 +3241,14 @@ public interface AdaptorinterfacePackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH = eINSTANCE.getAdaptorInterface_JavascriptFilesBasePath();
+
+		/**
+		 * The meta object literal for the '<em><b>Swagger Documentation</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION = eINSTANCE.getAdaptorInterface_SwaggerDocumentation();
 
 		/**
 		 * The meta object literal for the '<em><b>Backend Code Template class Imports</b></em>' attribute feature.

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorInterfaceImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorInterfaceImpl.java
@@ -40,6 +40,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getJavaFilesBasePath <em>Java Files Base Path</em>}</li>
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getJspFilesBasePath <em>Jsp Files Base Path</em>}</li>
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getJavascriptFilesBasePath <em>Javascript Files Base Path</em>}</li>
+ *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#isSwaggerDocumentation <em>Swagger Documentation</em>}</li>
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getBackendCodeTemplate_classImports <em>Backend Code Template class Imports</em>}</li>
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getBackendCodeTemplate_classMethods <em>Backend Code Template class Methods</em>}</li>
  *   <li>{@link adaptorinterface.impl.AdaptorInterfaceImpl#getBackendCodeTemplate_servletListenerInitialize <em>Backend Code Template servlet Listener Initialize</em>}</li>
@@ -183,6 +184,26 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 	 * @ordered
 	 */
 	protected String javascriptFilesBasePath = JAVASCRIPT_FILES_BASE_PATH_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isSwaggerDocumentation() <em>Swagger Documentation</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isSwaggerDocumentation()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean SWAGGER_DOCUMENTATION_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isSwaggerDocumentation() <em>Swagger Documentation</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isSwaggerDocumentation()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean swaggerDocumentation = SWAGGER_DOCUMENTATION_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getBackendCodeTemplate_classImports() <em>Backend Code Template class Imports</em>}' attribute.
@@ -579,6 +600,27 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public boolean isSwaggerDocumentation() {
+		return swaggerDocumentation;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setSwaggerDocumentation(boolean newSwaggerDocumentation) {
+		boolean oldSwaggerDocumentation = swaggerDocumentation;
+		swaggerDocumentation = newSwaggerDocumentation;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION, oldSwaggerDocumentation, swaggerDocumentation));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public String getBackendCodeTemplate_classImports() {
 		return backendCodeTemplate_classImports;
 	}
@@ -817,6 +859,8 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 				return getJspFilesBasePath();
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH:
 				return getJavascriptFilesBasePath();
+			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION:
+				return isSwaggerDocumentation();
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS:
 				return getBackendCodeTemplate_classImports();
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS:
@@ -872,6 +916,9 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 				return;
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH:
 				setJavascriptFilesBasePath((String)newValue);
+				return;
+			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION:
+				setSwaggerDocumentation((Boolean)newValue);
 				return;
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS:
 				setBackendCodeTemplate_classImports((String)newValue);
@@ -936,6 +983,9 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH:
 				setJavascriptFilesBasePath(JAVASCRIPT_FILES_BASE_PATH_EDEFAULT);
 				return;
+			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION:
+				setSwaggerDocumentation(SWAGGER_DOCUMENTATION_EDEFAULT);
+				return;
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS:
 				setBackendCodeTemplate_classImports(BACKEND_CODE_TEMPLATE_CLASS_IMPORTS_EDEFAULT);
 				return;
@@ -991,6 +1041,8 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 				return JSP_FILES_BASE_PATH_EDEFAULT == null ? jspFilesBasePath != null : !JSP_FILES_BASE_PATH_EDEFAULT.equals(jspFilesBasePath);
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH:
 				return JAVASCRIPT_FILES_BASE_PATH_EDEFAULT == null ? javascriptFilesBasePath != null : !JAVASCRIPT_FILES_BASE_PATH_EDEFAULT.equals(javascriptFilesBasePath);
+			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION:
+				return swaggerDocumentation != SWAGGER_DOCUMENTATION_EDEFAULT;
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS:
 				return BACKEND_CODE_TEMPLATE_CLASS_IMPORTS_EDEFAULT == null ? backendCodeTemplate_classImports != null : !BACKEND_CODE_TEMPLATE_CLASS_IMPORTS_EDEFAULT.equals(backendCodeTemplate_classImports);
 			case AdaptorinterfacePackage.ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS:
@@ -1033,6 +1085,8 @@ public class AdaptorInterfaceImpl extends MinimalEObjectImpl.Container implement
 		result.append(jspFilesBasePath);
 		result.append(", javascriptFilesBasePath: ");
 		result.append(javascriptFilesBasePath);
+		result.append(", swaggerDocumentation: ");
+		result.append(swaggerDocumentation);
 		result.append(", backendCodeTemplate_classImports: ");
 		result.append(backendCodeTemplate_classImports);
 		result.append(", backendCodeTemplate_classMethods: ");

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -386,7 +386,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_classImports() {
+	public EAttribute getAdaptorInterface_SwaggerDocumentation() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(8);
 	}
 
@@ -395,7 +395,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_classMethods() {
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_classImports() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(9);
 	}
 
@@ -404,7 +404,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_servletListenerInitialize() {
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_classMethods() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(10);
 	}
 
@@ -413,7 +413,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_servletListenerDestroy() {
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_servletListenerInitialize() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(11);
 	}
 
@@ -422,8 +422,17 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_getServiceProviders() {
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_servletListenerDestroy() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(12);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_getServiceProviders() {
+		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(13);
 	}
 
 	/**
@@ -441,24 +450,6 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * @generated
 	 */
 	public EAttribute getAdaptorInterface_BackendCodeTemplate_getResources() {
-		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(14);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_getResource() {
-		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(13);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_searchResources() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(15);
 	}
 
@@ -467,8 +458,26 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getAdaptorInterface_BackendCodeTemplate_createResource() {
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_getResource() {
+		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(14);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_searchResources() {
 		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(16);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getAdaptorInterface_BackendCodeTemplate_createResource() {
+		return (EAttribute)adaptorInterfaceEClass.getEStructuralFeatures().get(17);
 	}
 
 	/**
@@ -1543,6 +1552,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__JAVA_FILES_BASE_PATH);
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__JSP_FILES_BASE_PATH);
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__JAVASCRIPT_FILES_BASE_PATH);
+		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__SWAGGER_DOCUMENTATION);
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_IMPORTS);
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_CLASS_METHODS);
 		createEAttribute(adaptorInterfaceEClass, ADAPTOR_INTERFACE__BACKEND_CODE_TEMPLATE_SERVLET_LISTENER_INITIALIZE);
@@ -1740,6 +1750,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 		initEAttribute(getAdaptorInterface_JavaFilesBasePath(), ecorePackage.getEString(), "javaFilesBasePath", null, 1, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getAdaptorInterface_JspFilesBasePath(), ecorePackage.getEString(), "jspFilesBasePath", null, 1, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getAdaptorInterface_JavascriptFilesBasePath(), ecorePackage.getEString(), "javascriptFilesBasePath", null, 1, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAdaptorInterface_SwaggerDocumentation(), ecorePackage.getEBoolean(), "swaggerDocumentation", null, 0, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getAdaptorInterface_BackendCodeTemplate_classImports(), ecorePackage.getEString(), "backendCodeTemplate_classImports", null, 0, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getAdaptorInterface_BackendCodeTemplate_classMethods(), ecorePackage.getEString(), "backendCodeTemplate_classMethods", null, 0, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getAdaptorInterface_BackendCodeTemplate_servletListenerInitialize(), ecorePackage.getEString(), "backendCodeTemplate_servletListenerInitialize", null, 0, 1, AdaptorInterface.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);


### PR DESCRIPTION
Provide a checkbox per adaptor which results in generation of all necessay swagger annotations.

To see the resulting code (and resulting documentation) run the adaptor-testing from
https://github.com/OSLC/lyo-adaptor-sample-modelling/tree/swagger/adaptor-testing-webapp

