### PR TITLE
Add logging statements to show what publicURI and servletPath are set

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServletListener.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServletListener.mtl
@@ -100,7 +100,9 @@ public class [javaClassNameForAdaptorServletListener(anAdaptorInterface) /] impl
             logger.log(Level.SEVERE, "servletListner encountered problems identifying the servlet URL pattern.", e1);
         }
         try {
+            logger.info("Setting public URI: " + baseUrl);
             OSLC4JUtils.setPublicURI(baseUrl);
+            logger.info("Setting servlet path: " + servletUrlPattern);
             OSLC4JUtils.setServletPath(servletUrlPattern);
         } catch (MalformedURLException e) {
             logger.log(Level.SEVERE, "servletListner encountered MalformedURLException.", e);


### PR DESCRIPTION
This fix was used to get to the bottom of https://github.com/EricssonResearch/scott-eu/issues/150 but will be useful during any adaptor startup.