### PR TITLE
Show Servlet Context Name on the homepage

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateIndexJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateIndexJsp.mtl
@@ -90,7 +90,7 @@ To revert to the default generated content, delete all content in this file, and
 <body>
 <div class="container">
     <div class="jumbotron">
-        <h1 class="display-3">Adaptor home!</h1>
+        <h1 class="display-3"><%= application.getServletContextName() %></h1>
         <p class="lead">This is a homepage of the <em>[anAdaptorInterface.name/]</em> that was generated using
             Eclipse Lyo Toolchain Designer.</p>
         <hr class="my-4">


### PR DESCRIPTION
This allows to ensure that the right web.xml is used just from the first sight:

<img width="1089" alt="bild" src="https://user-images.githubusercontent.com/64734/54169087-a0b94380-4471-11e9-855b-3791191486e4.png">
