### PR TITLE
#61 OslcCoreMissingSetMethodException due to a regression in LyoD

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorClient.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorClient.mtl
@@ -98,7 +98,7 @@ public class [javaClassNameForClient(aRequiredAdaptor) /]
 [for (aResource: Resource | servicedResources(aRequiredAdaptor)->sortedBy(name)) separator(lineSeparator()) ]
     public static [javaClassName(aResource) /] get[javaName(aResource, true)/](String resourceURI) throws Exception {
         OslcClient client = new OslcClient();
-        ClientResponse response = null;
+        Response response = null;
         [javaClassName(aResource) /] resource = null;
 
         // [protected ('get'.concat(javaName(aResource, true)).concat('_init'))]
@@ -106,7 +106,7 @@ public class [javaClassNameForClient(aRequiredAdaptor) /]
 
         response = client.getResource(resourceURI, OSLCConstants.CT_RDF);
         if (response != null) {
-            resource = response.getEntity([javaClassName(aResource) /].class);
+            resource = response.readEntity([javaClassName(aResource) /].class);
         }
         // [protected ('get'.concat(javaName(aResource, true)).concat('_final'))]
         // [/protected]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
@@ -187,7 +187,7 @@ public class [javaClassName(aResource) /]
 [for (aProperty: ResourceProperty | ((aResource.resourceProperties->asSequence())->union(interfaceProperties(aResource))))]
 // [protected ('attributeAnnotation:'.concat(javaAttributeName(aProperty, aResource)))]
 // [/protected]
-private [javaAttributeTypeDeclaration(aProperty) /] [javaAttributeName(aProperty, aResource)/][if javaAttributeTypeNeedsConstruction(aProperty)] = new [javaAttributeTypeDeclaration(aProperty)/]()[/if];
+private [javaAttributeTypeDeclaration(aProperty) /] [javaAttributeName(aProperty, aResource)/][javaAttributeInitialConstruction(aProperty)/];
 [/for]
 [/template]
 
@@ -406,7 +406,7 @@ public [javaAttributeTypeDeclaration(aProperty) /] [javaAttributeGetterMethodNam
 [for (aProperty: ResourceProperty | ((aResource.resourceProperties->asSequence())->union(interfaceProperties(aResource))))]
 // [protected ('setterAnnotation:'.concat(javaAttributeName(aProperty, aResource)))]
 // [/protected]
-public void [javaAttributeSetterMethodName(aProperty, aResource)/](final [javaAttributeTypeDeclarationIn(aProperty) /] [javaName(aProperty, false)/] )
+public void [javaAttributeSetterMethodName(aProperty, aResource)/](final [javaAttributeTypeDeclaration(aProperty) /] [javaName(aProperty, false)/] )
 {
     // [protected ('setterInit:'.concat(javaAttributeName(aProperty, aResource)))]
     // [/protected]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
@@ -163,7 +163,7 @@ public interface [javaInterfaceName(aResource) /]
 [/for]
 
 [for (aProperty: ResourceProperty | aResource.resourceProperties)]
-    public void set[javaAttributeName(aProperty, aResource).toUpperFirst()/](final [javaAttributeTypeDeclarationIn(aProperty) /] [javaName(aProperty, false)/] );
+    public void set[javaAttributeName(aProperty, aResource).toUpperFirst()/](final [javaAttributeTypeDeclaration(aProperty) /] [javaName(aProperty, false)/] );
 [/for]
 }
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
@@ -180,7 +180,7 @@ aProperty.definingDomainSpecification().namespaceURI.concat('#').concat(javaName
 /]
 
 [query private javaAttributeTypeNeedsConstruction(aProperty: ResourceProperty) : Boolean =
-Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString())._or(Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString()))
+Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString())
 /]
 
 [query public javaAttributeBaseTypeCastFromString(aProperty: ResourceProperty, variable: String) : String =

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
@@ -179,7 +179,7 @@ endif)
 aProperty.definingDomainSpecification().namespaceURI.concat('#').concat(javaName(aProperty, false))
 /]
 
-[query public javaAttributeTypeNeedsConstruction(aProperty: ResourceProperty) : Boolean =
+[query private javaAttributeTypeNeedsConstruction(aProperty: ResourceProperty) : Boolean =
 Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString())._or(Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString()))
 /]
 
@@ -235,7 +235,7 @@ Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString()).
 [comment TODO: If occurs = 'zeroOrMany', it is not 100% clear when to use Set and when to use ArrayList, or TreeSet./]
 [query public javaAttributeTypeDeclaration(aProperty: ResourceProperty) : String =
     (if (Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString())) then
-        'HashSet<'
+        'Set<'
     else
         ''
     endif)
@@ -248,19 +248,12 @@ Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString()).
     endif))
 /]
 
-[query public javaAttributeTypeDeclarationIn(aProperty: ResourceProperty) : String =
-    (if (Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString())) then
-        'Set<'
+[query public javaAttributeInitialConstruction(aProperty: ResourceProperty) : String =
+    (if (javaAttributeTypeNeedsConstruction(aProperty)) then
+        ' = new '.concat('HashSet<').concat(javaAttributeBaseType(aProperty)).concat('>').concat('()')
     else
         ''
     endif)
-	.concat(javaAttributeBaseType(aProperty))
-	.concat(
-    (if (Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString())) then
-        '>'
-    else
-        ''
-    endif))
 /]
 
 [comment For Resource properties, we always have a Link type. That is how OSLC4 wants it. /]


### PR DESCRIPTION
#61 OslcCoreMissingSetMethodException due to a regression in LyoD

Resource properties of cardinality zero-or-one or zero-or-many are declared as Set. They are constructed as HashSet.

 