### PR TITLE
Specify keys for EAttributes within their containing EClass

### DIFF
--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -40,9 +40,9 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Specification">
     <eStructuralFeatures xsi:type="ecore:EReference" name="domainSpecifications" upperBound="-1"
-        eType="#//DomainSpecification" containment="true"/>
+        eType="#//DomainSpecification" containment="true" eKeys="#//DomainSpecification/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="domainPrefixes" upperBound="-1"
-        eType="#//NamespacePrefix" containment="true"/>
+        eType="#//NamespacePrefix" containment="true" eKeys="#//NamespacePrefix/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="generationSetting" eType="#//GenerationSetting"
         containment="true"/>
   </eClassifiers>
@@ -53,15 +53,15 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="namespacePrefix" lowerBound="1"
         eType="#//NamespacePrefix"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="resources" upperBound="-1"
-        eType="#//Resource" containment="true"/>
+        eType="#//Resource" containment="true" eKeys="#//Resource/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="resourceProperties" upperBound="-1"
-        eType="#//ResourceProperty" containment="true"/>
+        eType="#//ResourceProperty" containment="true" eKeys="#//ResourceProperty/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="generationSetting" eType="#//GenerationSetting"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="shaclShapes" upperBound="-1"
-        eType="#//ShaclShape" containment="true"/>
+        eType="#//ShaclShape" containment="true" eKeys="#//ShaclShape/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="shaclProperties" upperBound="-1"
-        eType="#//ShaclProperty" containment="true"/>
+        eType="#//ShaclProperty" containment="true" eKeys="#//ShaclProperty/name"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NamespacePrefix">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -63,7 +63,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/javaFilesBasePath"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/jspFilesBasePath"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/javascriptFilesBasePath"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/swaggerSupport"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/swaggerDocumentation"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_classImports"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_classMethods"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//AdaptorInterface/backendCodeTemplate_servletListenerInitialize"/>

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/vocabulary.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/vocabulary.ecore
@@ -4,7 +4,7 @@
     nsPrefix="oscl4j_vocabulary">
   <eClassifiers xsi:type="ecore:EClass" name="Vocabularies">
     <eStructuralFeatures xsi:type="ecore:EReference" name="vocabularies" upperBound="-1"
-        eType="#//Vocabulary" containment="true"/>
+        eType="#//Vocabulary" containment="true" eKeys="#//Vocabulary/label"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Vocabulary">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="namespaceURI" lowerBound="1"
@@ -26,9 +26,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="preferredNamespacePrefix"
         lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="classes" upperBound="-1"
-        eType="#//Class" containment="true"/>
+        eType="#//Class" containment="true" eKeys="#//Term/name"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="properties" upperBound="-1"
-        eType="#//Property" containment="true"/>
+        eType="#//Property" containment="true" eKeys="#//Term/name"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Term" abstract="true">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/DomainSpecification.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/DomainSpecification.java
@@ -119,7 +119,7 @@ public interface DomainSpecification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Resources</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getDomainSpecification_Resources()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<Resource> getResources();
@@ -135,7 +135,7 @@ public interface DomainSpecification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Resource Properties</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getDomainSpecification_ResourceProperties()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<ResourceProperty> getResourceProperties();
@@ -177,7 +177,7 @@ public interface DomainSpecification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Shacl Shapes</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getDomainSpecification_ShaclShapes()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<ShaclShape> getShaclShapes();
@@ -193,7 +193,7 @@ public interface DomainSpecification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Shacl Properties</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getDomainSpecification_ShaclProperties()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<ShaclProperty> getShaclProperties();

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Specification.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Specification.java
@@ -36,7 +36,7 @@ public interface Specification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Domain Specifications</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getSpecification_DomainSpecifications()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<DomainSpecification> getDomainSpecifications();
@@ -52,7 +52,7 @@ public interface Specification extends EObject {
 	 * <!-- end-user-doc -->
 	 * @return the value of the '<em>Domain Prefixes</em>' containment reference list.
 	 * @see adaptorinterface.AdaptorinterfacePackage#getSpecification_DomainPrefixes()
-	 * @model containment="true"
+     * @model containment="true" keys="name"
 	 * @generated
 	 */
 	EList<NamespacePrefix> getDomainPrefixes();

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -1763,7 +1763,9 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 
 		initEClass(specificationEClass, Specification.class, "Specification", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getSpecification_DomainSpecifications(), this.getDomainSpecification(), null, "domainSpecifications", null, 0, -1, Specification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getSpecification_DomainSpecifications().getEKeys().add(this.getDomainSpecification_Name());
 		initEReference(getSpecification_DomainPrefixes(), this.getNamespacePrefix(), null, "domainPrefixes", null, 0, -1, Specification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getSpecification_DomainPrefixes().getEKeys().add(this.getNamespacePrefix_Name());
 		initEReference(getSpecification_GenerationSetting(), this.getGenerationSetting(), null, "generationSetting", null, 0, 1, Specification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(domainSpecificationEClass, DomainSpecification.class, "DomainSpecification", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -1771,10 +1773,14 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 		initEAttribute(getDomainSpecification_NamespaceURI(), ecorePackage.getEString(), "namespaceURI", null, 1, 1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getDomainSpecification_NamespacePrefix(), this.getNamespacePrefix(), null, "namespacePrefix", null, 1, 1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getDomainSpecification_Resources(), this.getResource(), null, "resources", null, 0, -1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getDomainSpecification_Resources().getEKeys().add(this.getResource_Name());
 		initEReference(getDomainSpecification_ResourceProperties(), this.getResourceProperty(), null, "resourceProperties", null, 0, -1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getDomainSpecification_ResourceProperties().getEKeys().add(this.getResourceProperty_Name());
 		initEReference(getDomainSpecification_GenerationSetting(), this.getGenerationSetting(), null, "generationSetting", null, 0, 1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getDomainSpecification_ShaclShapes(), this.getShaclShape(), null, "shaclShapes", null, 0, -1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getDomainSpecification_ShaclShapes().getEKeys().add(this.getShaclShape_Name());
 		initEReference(getDomainSpecification_ShaclProperties(), this.getShaclProperty(), null, "shaclProperties", null, 0, -1, DomainSpecification.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getDomainSpecification_ShaclProperties().getEKeys().add(this.getShaclProperty_Name());
 
 		initEClass(namespacePrefixEClass, NamespacePrefix.class, "NamespacePrefix", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getNamespacePrefix_Name(), ecorePackage.getEString(), "name", null, 1, 1, NamespacePrefix.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/org.eclipse.lyo.tools.toolchain.editor/src/toolchain/presentation/ToolchainEditor.java
+++ b/org.eclipse.lyo.tools.toolchain.editor/src/toolchain/presentation/ToolchainEditor.java
@@ -172,1653 +172,1654 @@ public class ToolchainEditor
 	extends MultiPageEditorPart
 	implements IEditingDomainProvider, ISelectionProvider, IMenuListener, IViewerProvider, IGotoMarker {
 	/**
-	 * This keeps track of the editing domain that is used to track all changes to the model.
-	 * <!-- begin-user-doc -->
+     * This keeps track of the editing domain that is used to track all changes to the model.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected AdapterFactoryEditingDomain editingDomain;
 
 	/**
-	 * This is the one adapter factory used for providing views of the model.
-	 * <!-- begin-user-doc -->
+     * This is the one adapter factory used for providing views of the model.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected ComposedAdapterFactory adapterFactory;
 
 	/**
-	 * This is the content outline page.
-	 * <!-- begin-user-doc -->
+     * This is the content outline page.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected IContentOutlinePage contentOutlinePage;
 
 	/**
-	 * This is a kludge...
-	 * <!-- begin-user-doc -->
+     * This is a kludge...
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected IStatusLineManager contentOutlineStatusLineManager;
 
 	/**
-	 * This is the content outline page's viewer.
-	 * <!-- begin-user-doc -->
+     * This is the content outline page's viewer.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TreeViewer contentOutlineViewer;
 
 	/**
-	 * This is the property sheet page.
-	 * <!-- begin-user-doc -->
+     * This is the property sheet page.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected List<PropertySheetPage> propertySheetPages = new ArrayList<PropertySheetPage>();
 
 	/**
-	 * This is the viewer that shadows the selection in the content outline.
-	 * The parent relation must be correctly defined for this to work.
-	 * <!-- begin-user-doc -->
+     * This is the viewer that shadows the selection in the content outline.
+     * The parent relation must be correctly defined for this to work.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TreeViewer selectionViewer;
 
 	/**
-	 * This inverts the roll of parent and child in the content provider and show parents as a tree.
-	 * <!-- begin-user-doc -->
+     * This inverts the roll of parent and child in the content provider and show parents as a tree.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TreeViewer parentViewer;
 
 	/**
-	 * This shows how a tree view works.
-	 * <!-- begin-user-doc -->
+     * This shows how a tree view works.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TreeViewer treeViewer;
 
 	/**
-	 * This shows how a list view works.
-	 * A list viewer doesn't support icons.
-	 * <!-- begin-user-doc -->
+     * This shows how a list view works.
+     * A list viewer doesn't support icons.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected ListViewer listViewer;
 
 	/**
-	 * This shows how a table view works.
-	 * A table can be used as a list with icons.
-	 * <!-- begin-user-doc -->
+     * This shows how a table view works.
+     * A table can be used as a list with icons.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TableViewer tableViewer;
 
 	/**
-	 * This shows how a tree view with columns works.
-	 * <!-- begin-user-doc -->
+     * This shows how a tree view with columns works.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected TreeViewer treeViewerWithColumns;
 
 	/**
-	 * This keeps track of the active viewer pane, in the book.
-	 * <!-- begin-user-doc -->
+     * This keeps track of the active viewer pane, in the book.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected ViewerPane currentViewerPane;
 
 	/**
-	 * This keeps track of the active content viewer, which may be either one of the viewers in the pages or the content outline viewer.
-	 * <!-- begin-user-doc -->
+     * This keeps track of the active content viewer, which may be either one of the viewers in the pages or the content outline viewer.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Viewer currentViewer;
 
 	/**
-	 * This listens to which ever viewer is active.
-	 * <!-- begin-user-doc -->
+     * This listens to which ever viewer is active.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected ISelectionChangedListener selectionChangedListener;
 
 	/**
-	 * This keeps track of all the {@link org.eclipse.jface.viewers.ISelectionChangedListener}s that are listening to this editor.
-	 * <!-- begin-user-doc -->
+     * This keeps track of all the {@link org.eclipse.jface.viewers.ISelectionChangedListener}s that are listening to this editor.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Collection<ISelectionChangedListener> selectionChangedListeners = new ArrayList<ISelectionChangedListener>();
 
 	/**
-	 * This keeps track of the selection of the editor as a whole.
-	 * <!-- begin-user-doc -->
+     * This keeps track of the selection of the editor as a whole.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected ISelection editorSelection = StructuredSelection.EMPTY;
 
 	/**
-	 * The MarkerHelper is responsible for creating workspace resource markers presented
-	 * in Eclipse's Problems View.
-	 * <!-- begin-user-doc -->
+     * The MarkerHelper is responsible for creating workspace resource markers presented
+     * in Eclipse's Problems View.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected MarkerHelper markerHelper = new EditUIMarkerHelper();
 
 	/**
-	 * This listens for when the outline becomes active
-	 * <!-- begin-user-doc -->
+     * This listens for when the outline becomes active
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected IPartListener partListener =
 		new IPartListener() {
-			public void partActivated(IWorkbenchPart p) {
-				if (p instanceof ContentOutline) {
-					if (((ContentOutline)p).getCurrentPage() == contentOutlinePage) {
-						getActionBarContributor().setActiveEditor(ToolchainEditor.this);
+            public void partActivated(IWorkbenchPart p) {
+                if (p instanceof ContentOutline) {
+                    if (((ContentOutline)p).getCurrentPage() == contentOutlinePage) {
+                        getActionBarContributor().setActiveEditor(ToolchainEditor.this);
 
-						setCurrentViewer(contentOutlineViewer);
-					}
-				}
-				else if (p instanceof PropertySheet) {
-					if (propertySheetPages.contains(((PropertySheet)p).getCurrentPage())) {
-						getActionBarContributor().setActiveEditor(ToolchainEditor.this);
-						handleActivate();
-					}
-				}
-				else if (p == ToolchainEditor.this) {
-					handleActivate();
-				}
-			}
-			public void partBroughtToTop(IWorkbenchPart p) {
-				// Ignore.
-			}
-			public void partClosed(IWorkbenchPart p) {
-				// Ignore.
-			}
-			public void partDeactivated(IWorkbenchPart p) {
-				// Ignore.
-			}
-			public void partOpened(IWorkbenchPart p) {
-				// Ignore.
-			}
-		};
+                        setCurrentViewer(contentOutlineViewer);
+                    }
+                }
+                else if (p instanceof PropertySheet) {
+                    if (propertySheetPages.contains(((PropertySheet)p).getCurrentPage())) {
+                        getActionBarContributor().setActiveEditor(ToolchainEditor.this);
+                        handleActivate();
+                    }
+                }
+                else if (p == ToolchainEditor.this) {
+                    handleActivate();
+                }
+            }
+            public void partBroughtToTop(IWorkbenchPart p) {
+                // Ignore.
+            }
+            public void partClosed(IWorkbenchPart p) {
+                // Ignore.
+            }
+            public void partDeactivated(IWorkbenchPart p) {
+                // Ignore.
+            }
+            public void partOpened(IWorkbenchPart p) {
+                // Ignore.
+            }
+        };
 
 	/**
-	 * Resources that have been removed since last activation.
-	 * <!-- begin-user-doc -->
+     * Resources that have been removed since last activation.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Collection<Resource> removedResources = new ArrayList<Resource>();
 
 	/**
-	 * Resources that have been changed since last activation.
-	 * <!-- begin-user-doc -->
+     * Resources that have been changed since last activation.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Collection<Resource> changedResources = new ArrayList<Resource>();
 
 	/**
-	 * Resources that have been saved.
-	 * <!-- begin-user-doc -->
+     * Resources that have been saved.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Collection<Resource> savedResources = new ArrayList<Resource>();
 
 	/**
-	 * Map to store the diagnostic associated with a resource.
-	 * <!-- begin-user-doc -->
+     * Map to store the diagnostic associated with a resource.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected Map<Resource, Diagnostic> resourceToDiagnosticMap = new LinkedHashMap<Resource, Diagnostic>();
 
 	/**
-	 * Controls whether the problem indication should be updated.
-	 * <!-- begin-user-doc -->
+     * Controls whether the problem indication should be updated.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected boolean updateProblemIndication = true;
 
 	/**
-	 * Adapter used to update the problem indication when resources are demanded loaded.
-	 * <!-- begin-user-doc -->
+     * Adapter used to update the problem indication when resources are demanded loaded.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected EContentAdapter problemIndicationAdapter =
 		new EContentAdapter() {
-			@Override
-			public void notifyChanged(Notification notification) {
-				if (notification.getNotifier() instanceof Resource) {
-					switch (notification.getFeatureID(Resource.class)) {
-						case Resource.RESOURCE__IS_LOADED:
-						case Resource.RESOURCE__ERRORS:
-						case Resource.RESOURCE__WARNINGS: {
-							Resource resource = (Resource)notification.getNotifier();
-							Diagnostic diagnostic = analyzeResourceProblems(resource, null);
-							if (diagnostic.getSeverity() != Diagnostic.OK) {
-								resourceToDiagnosticMap.put(resource, diagnostic);
-							}
-							else {
-								resourceToDiagnosticMap.remove(resource);
-							}
+            protected boolean dispatching;
 
-							if (updateProblemIndication) {
-								getSite().getShell().getDisplay().asyncExec
-									(new Runnable() {
-										 public void run() {
-											 updateProblemIndication();
-										 }
-									 });
-							}
-							break;
-						}
-					}
-				}
-				else {
-					super.notifyChanged(notification);
-				}
-			}
+            @Override
+            public void notifyChanged(Notification notification) {
+                if (notification.getNotifier() instanceof Resource) {
+                    switch (notification.getFeatureID(Resource.class)) {
+                        case Resource.RESOURCE__IS_LOADED:
+                        case Resource.RESOURCE__ERRORS:
+                        case Resource.RESOURCE__WARNINGS: {
+                            Resource resource = (Resource)notification.getNotifier();
+                            Diagnostic diagnostic = analyzeResourceProblems(resource, null);
+                            if (diagnostic.getSeverity() != Diagnostic.OK) {
+                                resourceToDiagnosticMap.put(resource, diagnostic);
+                            }
+                            else {
+                                resourceToDiagnosticMap.remove(resource);
+                            }
+                            dispatchUpdateProblemIndication();
+                            break;
+                        }
+                    }
+                }
+                else {
+                    super.notifyChanged(notification);
+                }
+            }
 
-			@Override
-			protected void setTarget(Resource target) {
-				basicSetTarget(target);
-			}
+            protected void dispatchUpdateProblemIndication() {
+                if (updateProblemIndication && !dispatching) {
+                    dispatching = true;
+                    getSite().getShell().getDisplay().asyncExec
+                        (new Runnable() {
+                             public void run() {
+                                 dispatching = false;
+                                 updateProblemIndication();
+                             }
+                         });
+                }
+            }
 
-			@Override
-			protected void unsetTarget(Resource target) {
-				basicUnsetTarget(target);
-				resourceToDiagnosticMap.remove(target);
-				if (updateProblemIndication) {
-					getSite().getShell().getDisplay().asyncExec
-						(new Runnable() {
-							 public void run() {
-								 updateProblemIndication();
-							 }
-						 });
-				}
-			}
-		};
+            @Override
+            protected void setTarget(Resource target) {
+                basicSetTarget(target);
+            }
+
+            @Override
+            protected void unsetTarget(Resource target) {
+                basicUnsetTarget(target);
+                resourceToDiagnosticMap.remove(target);
+                dispatchUpdateProblemIndication();
+            }
+        };
 
 	/**
-	 * This listens for workspace changes.
-	 * <!-- begin-user-doc -->
+     * This listens for workspace changes.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected IResourceChangeListener resourceChangeListener =
 		new IResourceChangeListener() {
-			public void resourceChanged(IResourceChangeEvent event) {
-				IResourceDelta delta = event.getDelta();
-				try {
-					class ResourceDeltaVisitor implements IResourceDeltaVisitor {
-						protected ResourceSet resourceSet = editingDomain.getResourceSet();
-						protected Collection<Resource> changedResources = new ArrayList<Resource>();
-						protected Collection<Resource> removedResources = new ArrayList<Resource>();
+            public void resourceChanged(IResourceChangeEvent event) {
+                IResourceDelta delta = event.getDelta();
+                try {
+                    class ResourceDeltaVisitor implements IResourceDeltaVisitor {
+                        protected ResourceSet resourceSet = editingDomain.getResourceSet();
+                        protected Collection<Resource> changedResources = new ArrayList<Resource>();
+                        protected Collection<Resource> removedResources = new ArrayList<Resource>();
 
-						public boolean visit(IResourceDelta delta) {
-							if (delta.getResource().getType() == IResource.FILE) {
-								if (delta.getKind() == IResourceDelta.REMOVED ||
-								    delta.getKind() == IResourceDelta.CHANGED && delta.getFlags() != IResourceDelta.MARKERS) {
-									Resource resource = resourceSet.getResource(URI.createPlatformResourceURI(delta.getFullPath().toString(), true), false);
-									if (resource != null) {
-										if (delta.getKind() == IResourceDelta.REMOVED) {
-											removedResources.add(resource);
-										}
-										else if (!savedResources.remove(resource)) {
-											changedResources.add(resource);
-										}
-									}
-								}
-								return false;
-							}
+                        public boolean visit(IResourceDelta delta) {
+                            if (delta.getResource().getType() == IResource.FILE) {
+                                if (delta.getKind() == IResourceDelta.REMOVED ||
+                                    delta.getKind() == IResourceDelta.CHANGED && delta.getFlags() != IResourceDelta.MARKERS) {
+                                    Resource resource = resourceSet.getResource(URI.createPlatformResourceURI(delta.getFullPath().toString(), true), false);
+                                    if (resource != null) {
+                                        if (delta.getKind() == IResourceDelta.REMOVED) {
+                                            removedResources.add(resource);
+                                        }
+                                        else if (!savedResources.remove(resource)) {
+                                            changedResources.add(resource);
+                                        }
+                                    }
+                                }
+                                return false;
+                            }
 
-							return true;
-						}
+                            return true;
+                        }
 
-						public Collection<Resource> getChangedResources() {
-							return changedResources;
-						}
+                        public Collection<Resource> getChangedResources() {
+                            return changedResources;
+                        }
 
-						public Collection<Resource> getRemovedResources() {
-							return removedResources;
-						}
-					}
+                        public Collection<Resource> getRemovedResources() {
+                            return removedResources;
+                        }
+                    }
 
-					final ResourceDeltaVisitor visitor = new ResourceDeltaVisitor();
-					delta.accept(visitor);
+                    final ResourceDeltaVisitor visitor = new ResourceDeltaVisitor();
+                    delta.accept(visitor);
 
-					if (!visitor.getRemovedResources().isEmpty()) {
-						getSite().getShell().getDisplay().asyncExec
-							(new Runnable() {
-								 public void run() {
-									 removedResources.addAll(visitor.getRemovedResources());
-									 if (!isDirty()) {
-										 getSite().getPage().closeEditor(ToolchainEditor.this, false);
-									 }
-								 }
-							 });
-					}
+                    if (!visitor.getRemovedResources().isEmpty()) {
+                        getSite().getShell().getDisplay().asyncExec
+                            (new Runnable() {
+                                 public void run() {
+                                     removedResources.addAll(visitor.getRemovedResources());
+                                     if (!isDirty()) {
+                                         getSite().getPage().closeEditor(ToolchainEditor.this, false);
+                                     }
+                                 }
+                             });
+                    }
 
-					if (!visitor.getChangedResources().isEmpty()) {
-						getSite().getShell().getDisplay().asyncExec
-							(new Runnable() {
-								 public void run() {
-									 changedResources.addAll(visitor.getChangedResources());
-									 if (getSite().getPage().getActiveEditor() == ToolchainEditor.this) {
-										 handleActivate();
-									 }
-								 }
-							 });
-					}
-				}
-				catch (CoreException exception) {
-					ToolchainEditorPlugin.INSTANCE.log(exception);
-				}
-			}
-		};
+                    if (!visitor.getChangedResources().isEmpty()) {
+                        getSite().getShell().getDisplay().asyncExec
+                            (new Runnable() {
+                                 public void run() {
+                                     changedResources.addAll(visitor.getChangedResources());
+                                     if (getSite().getPage().getActiveEditor() == ToolchainEditor.this) {
+                                         handleActivate();
+                                     }
+                                 }
+                             });
+                    }
+                }
+                catch (CoreException exception) {
+                    ToolchainEditorPlugin.INSTANCE.log(exception);
+                }
+            }
+        };
 
 	/**
-	 * Handles activation of the editor or it's associated views.
-	 * <!-- begin-user-doc -->
+     * Handles activation of the editor or it's associated views.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void handleActivate() {
-		// Recompute the read only state.
-		//
-		if (editingDomain.getResourceToReadOnlyMap() != null) {
-		  editingDomain.getResourceToReadOnlyMap().clear();
+        // Recompute the read only state.
+        //
+        if (editingDomain.getResourceToReadOnlyMap() != null) {
+          editingDomain.getResourceToReadOnlyMap().clear();
 
-		  // Refresh any actions that may become enabled or disabled.
-		  //
-		  setSelection(getSelection());
-		}
+          // Refresh any actions that may become enabled or disabled.
+          //
+          setSelection(getSelection());
+        }
 
-		if (!removedResources.isEmpty()) {
-			if (handleDirtyConflict()) {
-				getSite().getPage().closeEditor(ToolchainEditor.this, false);
-			}
-			else {
-				removedResources.clear();
-				changedResources.clear();
-				savedResources.clear();
-			}
-		}
-		else if (!changedResources.isEmpty()) {
-			changedResources.removeAll(savedResources);
-			handleChangedResources();
-			changedResources.clear();
-			savedResources.clear();
-		}
-	}
+        if (!removedResources.isEmpty()) {
+            if (handleDirtyConflict()) {
+                getSite().getPage().closeEditor(ToolchainEditor.this, false);
+            }
+            else {
+                removedResources.clear();
+                changedResources.clear();
+                savedResources.clear();
+            }
+        }
+        else if (!changedResources.isEmpty()) {
+            changedResources.removeAll(savedResources);
+            handleChangedResources();
+            changedResources.clear();
+            savedResources.clear();
+        }
+    }
 
 	/**
-	 * Handles what to do with changed resources on activation.
-	 * <!-- begin-user-doc -->
+     * Handles what to do with changed resources on activation.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void handleChangedResources() {
-		if (!changedResources.isEmpty() && (!isDirty() || handleDirtyConflict())) {
-			if (isDirty()) {
-				changedResources.addAll(editingDomain.getResourceSet().getResources());
-			}
-			editingDomain.getCommandStack().flush();
+        if (!changedResources.isEmpty() && (!isDirty() || handleDirtyConflict())) {
+            if (isDirty()) {
+                changedResources.addAll(editingDomain.getResourceSet().getResources());
+            }
+            editingDomain.getCommandStack().flush();
 
-			updateProblemIndication = false;
-			for (Resource resource : changedResources) {
-				if (resource.isLoaded()) {
-					resource.unload();
-					try {
-						resource.load(Collections.EMPTY_MAP);
-					}
-					catch (IOException exception) {
-						if (!resourceToDiagnosticMap.containsKey(resource)) {
-							resourceToDiagnosticMap.put(resource, analyzeResourceProblems(resource, exception));
-						}
-					}
-				}
-			}
+            updateProblemIndication = false;
+            for (Resource resource : changedResources) {
+                if (resource.isLoaded()) {
+                    resource.unload();
+                    try {
+                        resource.load(Collections.EMPTY_MAP);
+                    }
+                    catch (IOException exception) {
+                        if (!resourceToDiagnosticMap.containsKey(resource)) {
+                            resourceToDiagnosticMap.put(resource, analyzeResourceProblems(resource, exception));
+                        }
+                    }
+                }
+            }
 
-			if (AdapterFactoryEditingDomain.isStale(editorSelection)) {
-				setSelection(StructuredSelection.EMPTY);
-			}
+            if (AdapterFactoryEditingDomain.isStale(editorSelection)) {
+                setSelection(StructuredSelection.EMPTY);
+            }
 
-			updateProblemIndication = true;
-			updateProblemIndication();
-		}
-	}
+            updateProblemIndication = true;
+            updateProblemIndication();
+        }
+    }
 
 	/**
-	 * Updates the problems indication with the information described in the specified diagnostic.
-	 * <!-- begin-user-doc -->
+     * Updates the problems indication with the information described in the specified diagnostic.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void updateProblemIndication() {
-		if (updateProblemIndication) {
-			BasicDiagnostic diagnostic =
-				new BasicDiagnostic
-					(Diagnostic.OK,
-					 "org.eclipse.lyo.tools.toolchain.editor",
-					 0,
-					 null,
-					 new Object [] { editingDomain.getResourceSet() });
-			for (Diagnostic childDiagnostic : resourceToDiagnosticMap.values()) {
-				if (childDiagnostic.getSeverity() != Diagnostic.OK) {
-					diagnostic.add(childDiagnostic);
-				}
-			}
+        if (updateProblemIndication) {
+            BasicDiagnostic diagnostic =
+                new BasicDiagnostic
+                    (Diagnostic.OK,
+                     "org.eclipse.lyo.tools.toolchain.editor",
+                     0,
+                     null,
+                     new Object [] { editingDomain.getResourceSet() });
+            for (Diagnostic childDiagnostic : resourceToDiagnosticMap.values()) {
+                if (childDiagnostic.getSeverity() != Diagnostic.OK) {
+                    diagnostic.add(childDiagnostic);
+                }
+            }
 
-			int lastEditorPage = getPageCount() - 1;
-			if (lastEditorPage >= 0 && getEditor(lastEditorPage) instanceof ProblemEditorPart) {
-				((ProblemEditorPart)getEditor(lastEditorPage)).setDiagnostic(diagnostic);
-				if (diagnostic.getSeverity() != Diagnostic.OK) {
-					setActivePage(lastEditorPage);
-				}
-			}
-			else if (diagnostic.getSeverity() != Diagnostic.OK) {
-				ProblemEditorPart problemEditorPart = new ProblemEditorPart();
-				problemEditorPart.setDiagnostic(diagnostic);
-				problemEditorPart.setMarkerHelper(markerHelper);
-				try {
-					addPage(++lastEditorPage, problemEditorPart, getEditorInput());
-					setPageText(lastEditorPage, problemEditorPart.getPartName());
-					setActivePage(lastEditorPage);
-					showTabs();
-				}
-				catch (PartInitException exception) {
-					ToolchainEditorPlugin.INSTANCE.log(exception);
-				}
-			}
+            int lastEditorPage = getPageCount() - 1;
+            if (lastEditorPage >= 0 && getEditor(lastEditorPage) instanceof ProblemEditorPart) {
+                ((ProblemEditorPart)getEditor(lastEditorPage)).setDiagnostic(diagnostic);
+                if (diagnostic.getSeverity() != Diagnostic.OK) {
+                    setActivePage(lastEditorPage);
+                }
+            }
+            else if (diagnostic.getSeverity() != Diagnostic.OK) {
+                ProblemEditorPart problemEditorPart = new ProblemEditorPart();
+                problemEditorPart.setDiagnostic(diagnostic);
+                problemEditorPart.setMarkerHelper(markerHelper);
+                try {
+                    addPage(++lastEditorPage, problemEditorPart, getEditorInput());
+                    setPageText(lastEditorPage, problemEditorPart.getPartName());
+                    setActivePage(lastEditorPage);
+                    showTabs();
+                }
+                catch (PartInitException exception) {
+                    ToolchainEditorPlugin.INSTANCE.log(exception);
+                }
+            }
 
-			if (markerHelper.hasMarkers(editingDomain.getResourceSet())) {
-				markerHelper.deleteMarkers(editingDomain.getResourceSet());
-				if (diagnostic.getSeverity() != Diagnostic.OK) {
-					try {
-						markerHelper.createMarkers(diagnostic);
-					}
-					catch (CoreException exception) {
-						ToolchainEditorPlugin.INSTANCE.log(exception);
-					}
-				}
-			}
-		}
-	}
+            if (markerHelper.hasMarkers(editingDomain.getResourceSet())) {
+                try {
+                    markerHelper.updateMarkers(diagnostic);
+                }
+                catch (CoreException exception) {
+                    ToolchainEditorPlugin.INSTANCE.log(exception);
+                }
+            }
+        }
+    }
 
 	/**
-	 * Shows a dialog that asks if conflicting changes should be discarded.
-	 * <!-- begin-user-doc -->
+     * Shows a dialog that asks if conflicting changes should be discarded.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected boolean handleDirtyConflict() {
-		return
-			MessageDialog.openQuestion
-				(getSite().getShell(),
-				 getString("_UI_FileConflict_label"),
-				 getString("_WARN_FileConflict"));
-	}
+        return
+            MessageDialog.openQuestion
+                (getSite().getShell(),
+                 getString("_UI_FileConflict_label"),
+                 getString("_WARN_FileConflict"));
+    }
 
 	/**
-	 * This creates a model editor.
-	 * <!-- begin-user-doc -->
+     * This creates a model editor.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public ToolchainEditor() {
-		super();
-		initializeEditingDomain();
-	}
+        super();
+        initializeEditingDomain();
+    }
 
 	/**
-	 * This sets up the editing domain for the model editor.
-	 * <!-- begin-user-doc -->
+     * This sets up the editing domain for the model editor.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void initializeEditingDomain() {
-		// Create an adapter factory that yields item providers.
-		//
-		adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+        // Create an adapter factory that yields item providers.
+        //
+        adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
 
-		adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
-		adapterFactory.addAdapterFactory(new ToolchainItemProviderAdapterFactory());
-		adapterFactory.addAdapterFactory(new AdaptorinterfaceItemProviderAdapterFactory());
-		adapterFactory.addAdapterFactory(new VocabularyItemProviderAdapterFactory());
-		adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+        adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
+        adapterFactory.addAdapterFactory(new ToolchainItemProviderAdapterFactory());
+        adapterFactory.addAdapterFactory(new AdaptorinterfaceItemProviderAdapterFactory());
+        adapterFactory.addAdapterFactory(new VocabularyItemProviderAdapterFactory());
+        adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
 
-		// Create the command stack that will notify this editor as commands are executed.
-		//
-		BasicCommandStack commandStack = new BasicCommandStack();
+        // Create the command stack that will notify this editor as commands are executed.
+        //
+        BasicCommandStack commandStack = new BasicCommandStack();
 
-		// Add a listener to set the most recent command's affected objects to be the selection of the viewer with focus.
-		//
-		commandStack.addCommandStackListener
-			(new CommandStackListener() {
-				 public void commandStackChanged(final EventObject event) {
-					 getContainer().getDisplay().asyncExec
-						 (new Runnable() {
-							  public void run() {
-								  firePropertyChange(IEditorPart.PROP_DIRTY);
+        // Add a listener to set the most recent command's affected objects to be the selection of the viewer with focus.
+        //
+        commandStack.addCommandStackListener
+            (new CommandStackListener() {
+                 public void commandStackChanged(final EventObject event) {
+                     getContainer().getDisplay().asyncExec
+                         (new Runnable() {
+                              public void run() {
+                                  firePropertyChange(IEditorPart.PROP_DIRTY);
 
-								  // Try to select the affected objects.
-								  //
-								  Command mostRecentCommand = ((CommandStack)event.getSource()).getMostRecentCommand();
-								  if (mostRecentCommand != null) {
-									  setSelectionToViewer(mostRecentCommand.getAffectedObjects());
-								  }
-								  for (Iterator<PropertySheetPage> i = propertySheetPages.iterator(); i.hasNext(); ) {
-									  PropertySheetPage propertySheetPage = i.next();
-									  if (propertySheetPage.getControl().isDisposed()) {
-										  i.remove();
-									  }
-									  else {
-										  propertySheetPage.refresh();
-									  }
-								  }
-							  }
-						  });
-				 }
-			 });
+                                  // Try to select the affected objects.
+                                  //
+                                  Command mostRecentCommand = ((CommandStack)event.getSource()).getMostRecentCommand();
+                                  if (mostRecentCommand != null) {
+                                      setSelectionToViewer(mostRecentCommand.getAffectedObjects());
+                                  }
+                                  for (Iterator<PropertySheetPage> i = propertySheetPages.iterator(); i.hasNext(); ) {
+                                      PropertySheetPage propertySheetPage = i.next();
+                                      if (propertySheetPage.getControl().isDisposed()) {
+                                          i.remove();
+                                      }
+                                      else {
+                                          propertySheetPage.refresh();
+                                      }
+                                  }
+                              }
+                          });
+                 }
+             });
 
-		// Create the editing domain with a special command stack.
-		//
-		editingDomain = new AdapterFactoryEditingDomain(adapterFactory, commandStack, new HashMap<Resource, Boolean>());
-	}
+        // Create the editing domain with a special command stack.
+        //
+        editingDomain = new AdapterFactoryEditingDomain(adapterFactory, commandStack, new HashMap<Resource, Boolean>());
+    }
 
 	/**
-	 * This is here for the listener to be able to call it.
-	 * <!-- begin-user-doc -->
+     * This is here for the listener to be able to call it.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 			@Override
 	protected void firePropertyChange(int action) {
-		super.firePropertyChange(action);
-	}
+        super.firePropertyChange(action);
+    }
 
 	/**
-	 * This sets the selection into whichever viewer is active.
-	 * <!-- begin-user-doc -->
+     * This sets the selection into whichever viewer is active.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void setSelectionToViewer(Collection<?> collection) {
-		final Collection<?> theSelection = collection;
-		// Make sure it's okay.
-		//
-		if (theSelection != null && !theSelection.isEmpty()) {
-			Runnable runnable =
-				new Runnable() {
-					public void run() {
-						// Try to select the items in the current content viewer of the editor.
-						//
-						if (currentViewer != null) {
-							currentViewer.setSelection(new StructuredSelection(theSelection.toArray()), true);
-						}
-					}
-				};
-			getSite().getShell().getDisplay().asyncExec(runnable);
-		}
-	}
+        final Collection<?> theSelection = collection;
+        // Make sure it's okay.
+        //
+        if (theSelection != null && !theSelection.isEmpty()) {
+            Runnable runnable =
+                new Runnable() {
+                    public void run() {
+                        // Try to select the items in the current content viewer of the editor.
+                        //
+                        if (currentViewer != null) {
+                            currentViewer.setSelection(new StructuredSelection(theSelection.toArray()), true);
+                        }
+                    }
+                };
+            getSite().getShell().getDisplay().asyncExec(runnable);
+        }
+    }
 
 	/**
-	 * This returns the editing domain as required by the {@link IEditingDomainProvider} interface.
-	 * This is important for implementing the static methods of {@link AdapterFactoryEditingDomain}
-	 * and for supporting {@link org.eclipse.emf.edit.ui.action.CommandAction}.
-	 * <!-- begin-user-doc -->
+     * This returns the editing domain as required by the {@link IEditingDomainProvider} interface.
+     * This is important for implementing the static methods of {@link AdapterFactoryEditingDomain}
+     * and for supporting {@link org.eclipse.emf.edit.ui.action.CommandAction}.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EditingDomain getEditingDomain() {
-		return editingDomain;
-	}
+        return editingDomain;
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public class ReverseAdapterFactoryContentProvider extends AdapterFactoryContentProvider {
 		/**
-		 * <!-- begin-user-doc -->
+         * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @generated
-		 */
+         * @generated
+         */
 		public ReverseAdapterFactoryContentProvider(AdapterFactory adapterFactory) {
-			super(adapterFactory);
-		}
+            super(adapterFactory);
+        }
 
 		/**
-		 * <!-- begin-user-doc -->
+         * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @generated
-		 */
+         * @generated
+         */
 		@Override
 		public Object [] getElements(Object object) {
-			Object parent = super.getParent(object);
-			return (parent == null ? Collections.EMPTY_SET : Collections.singleton(parent)).toArray();
-		}
+            Object parent = super.getParent(object);
+            return (parent == null ? Collections.EMPTY_SET : Collections.singleton(parent)).toArray();
+        }
 
 		/**
-		 * <!-- begin-user-doc -->
+         * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @generated
-		 */
+         * @generated
+         */
 		@Override
 		public Object [] getChildren(Object object) {
-			Object parent = super.getParent(object);
-			return (parent == null ? Collections.EMPTY_SET : Collections.singleton(parent)).toArray();
-		}
+            Object parent = super.getParent(object);
+            return (parent == null ? Collections.EMPTY_SET : Collections.singleton(parent)).toArray();
+        }
 
 		/**
-		 * <!-- begin-user-doc -->
+         * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @generated
-		 */
+         * @generated
+         */
 		@Override
 		public boolean hasChildren(Object object) {
-			Object parent = super.getParent(object);
-			return parent != null;
-		}
+            Object parent = super.getParent(object);
+            return parent != null;
+        }
 
 		/**
-		 * <!-- begin-user-doc -->
+         * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
-		 * @generated
-		 */
+         * @generated
+         */
 		@Override
 		public Object getParent(Object object) {
-			return null;
-		}
+            return null;
+        }
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void setCurrentViewerPane(ViewerPane viewerPane) {
-		if (currentViewerPane != viewerPane) {
-			if (currentViewerPane != null) {
-				currentViewerPane.showFocus(false);
-			}
-			currentViewerPane = viewerPane;
-		}
-		setCurrentViewer(currentViewerPane.getViewer());
-	}
+        if (currentViewerPane != viewerPane) {
+            if (currentViewerPane != null) {
+                currentViewerPane.showFocus(false);
+            }
+            currentViewerPane = viewerPane;
+        }
+        setCurrentViewer(currentViewerPane.getViewer());
+    }
 
 	/**
-	 * This makes sure that one content viewer, either for the current page or the outline view, if it has focus,
-	 * is the current one.
-	 * <!-- begin-user-doc -->
+     * This makes sure that one content viewer, either for the current page or the outline view, if it has focus,
+     * is the current one.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void setCurrentViewer(Viewer viewer) {
-		// If it is changing...
-		//
-		if (currentViewer != viewer) {
-			if (selectionChangedListener == null) {
-				// Create the listener on demand.
-				//
-				selectionChangedListener =
-					new ISelectionChangedListener() {
-						// This just notifies those things that are affected by the section.
-						//
-						public void selectionChanged(SelectionChangedEvent selectionChangedEvent) {
-							setSelection(selectionChangedEvent.getSelection());
-						}
-					};
-			}
+        // If it is changing...
+        //
+        if (currentViewer != viewer) {
+            if (selectionChangedListener == null) {
+                // Create the listener on demand.
+                //
+                selectionChangedListener =
+                    new ISelectionChangedListener() {
+                        // This just notifies those things that are affected by the section.
+                        //
+                        public void selectionChanged(SelectionChangedEvent selectionChangedEvent) {
+                            setSelection(selectionChangedEvent.getSelection());
+                        }
+                    };
+            }
 
-			// Stop listening to the old one.
-			//
-			if (currentViewer != null) {
-				currentViewer.removeSelectionChangedListener(selectionChangedListener);
-			}
+            // Stop listening to the old one.
+            //
+            if (currentViewer != null) {
+                currentViewer.removeSelectionChangedListener(selectionChangedListener);
+            }
 
-			// Start listening to the new one.
-			//
-			if (viewer != null) {
-				viewer.addSelectionChangedListener(selectionChangedListener);
-			}
+            // Start listening to the new one.
+            //
+            if (viewer != null) {
+                viewer.addSelectionChangedListener(selectionChangedListener);
+            }
 
-			// Remember it.
-			//
-			currentViewer = viewer;
+            // Remember it.
+            //
+            currentViewer = viewer;
 
-			// Set the editors selection based on the current viewer's selection.
-			//
-			setSelection(currentViewer == null ? StructuredSelection.EMPTY : currentViewer.getSelection());
-		}
-	}
+            // Set the editors selection based on the current viewer's selection.
+            //
+            setSelection(currentViewer == null ? StructuredSelection.EMPTY : currentViewer.getSelection());
+        }
+    }
 
 	/**
-	 * This returns the viewer as required by the {@link IViewerProvider} interface.
-	 * <!-- begin-user-doc -->
+     * This returns the viewer as required by the {@link IViewerProvider} interface.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public Viewer getViewer() {
-		return currentViewer;
-	}
+        return currentViewer;
+    }
 
 	/**
-	 * This creates a context menu for the viewer and adds a listener as well registering the menu for extension.
-	 * <!-- begin-user-doc -->
+     * This creates a context menu for the viewer and adds a listener as well registering the menu for extension.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void createContextMenuFor(StructuredViewer viewer) {
-		MenuManager contextMenu = new MenuManager("#PopUp");
-		contextMenu.add(new Separator("additions"));
-		contextMenu.setRemoveAllWhenShown(true);
-		contextMenu.addMenuListener(this);
-		Menu menu= contextMenu.createContextMenu(viewer.getControl());
-		viewer.getControl().setMenu(menu);
-		getSite().registerContextMenu(contextMenu, new UnwrappingSelectionProvider(viewer));
+        MenuManager contextMenu = new MenuManager("#PopUp");
+        contextMenu.add(new Separator("additions"));
+        contextMenu.setRemoveAllWhenShown(true);
+        contextMenu.addMenuListener(this);
+        Menu menu= contextMenu.createContextMenu(viewer.getControl());
+        viewer.getControl().setMenu(menu);
+        getSite().registerContextMenu(contextMenu, new UnwrappingSelectionProvider(viewer));
 
-		int dndOperations = DND.DROP_COPY | DND.DROP_MOVE | DND.DROP_LINK;
-		Transfer[] transfers = new Transfer[] { LocalTransfer.getInstance(), LocalSelectionTransfer.getTransfer(), FileTransfer.getInstance() };
-		viewer.addDragSupport(dndOperations, transfers, new ViewerDragAdapter(viewer));
-		viewer.addDropSupport(dndOperations, transfers, new EditingDomainViewerDropAdapter(editingDomain, viewer));
-	}
+        int dndOperations = DND.DROP_COPY | DND.DROP_MOVE | DND.DROP_LINK;
+        Transfer[] transfers = new Transfer[] { LocalTransfer.getInstance(), LocalSelectionTransfer.getTransfer(), FileTransfer.getInstance() };
+        viewer.addDragSupport(dndOperations, transfers, new ViewerDragAdapter(viewer));
+        viewer.addDropSupport(dndOperations, transfers, new EditingDomainViewerDropAdapter(editingDomain, viewer));
+    }
 
 	/**
-	 * This is the method called to load a resource into the editing domain's resource set based on the editor's input.
-	 * <!-- begin-user-doc -->
+     * This is the method called to load a resource into the editing domain's resource set based on the editor's input.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void createModel() {
-		URI resourceURI = EditUIUtil.getURI(getEditorInput(), editingDomain.getResourceSet().getURIConverter());
-		Exception exception = null;
-		Resource resource = null;
-		try {
-			// Load the resource through the editing domain.
-			//
-			resource = editingDomain.getResourceSet().getResource(resourceURI, true);
-		}
-		catch (Exception e) {
-			exception = e;
-			resource = editingDomain.getResourceSet().getResource(resourceURI, false);
-		}
+        URI resourceURI = EditUIUtil.getURI(getEditorInput(), editingDomain.getResourceSet().getURIConverter());
+        Exception exception = null;
+        Resource resource = null;
+        try {
+            // Load the resource through the editing domain.
+            //
+            resource = editingDomain.getResourceSet().getResource(resourceURI, true);
+        }
+        catch (Exception e) {
+            exception = e;
+            resource = editingDomain.getResourceSet().getResource(resourceURI, false);
+        }
 
-		Diagnostic diagnostic = analyzeResourceProblems(resource, exception);
-		if (diagnostic.getSeverity() != Diagnostic.OK) {
-			resourceToDiagnosticMap.put(resource,  analyzeResourceProblems(resource, exception));
-		}
-		editingDomain.getResourceSet().eAdapters().add(problemIndicationAdapter);
-	}
+        Diagnostic diagnostic = analyzeResourceProblems(resource, exception);
+        if (diagnostic.getSeverity() != Diagnostic.OK) {
+            resourceToDiagnosticMap.put(resource,  analyzeResourceProblems(resource, exception));
+        }
+        editingDomain.getResourceSet().eAdapters().add(problemIndicationAdapter);
+    }
 
 	/**
-	 * Returns a diagnostic describing the errors and warnings listed in the resource
-	 * and the specified exception (if any).
-	 * <!-- begin-user-doc -->
+     * Returns a diagnostic describing the errors and warnings listed in the resource
+     * and the specified exception (if any).
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public Diagnostic analyzeResourceProblems(Resource resource, Exception exception) {
-		boolean hasErrors = !resource.getErrors().isEmpty();
-		if (hasErrors || !resource.getWarnings().isEmpty()) {
-			BasicDiagnostic basicDiagnostic =
-				new BasicDiagnostic
-					(hasErrors ? Diagnostic.ERROR : Diagnostic.WARNING,
-					 "org.eclipse.lyo.tools.toolchain.editor",
-					 0,
-					 getString("_UI_CreateModelError_message", resource.getURI()),
-					 new Object [] { exception == null ? (Object)resource : exception });
-			basicDiagnostic.merge(EcoreUtil.computeDiagnostic(resource, true));
-			return basicDiagnostic;
-		}
-		else if (exception != null) {
-			return
-				new BasicDiagnostic
-					(Diagnostic.ERROR,
-					 "org.eclipse.lyo.tools.toolchain.editor",
-					 0,
-					 getString("_UI_CreateModelError_message", resource.getURI()),
-					 new Object[] { exception });
-		}
-		else {
-			return Diagnostic.OK_INSTANCE;
-		}
-	}
+        boolean hasErrors = !resource.getErrors().isEmpty();
+        if (hasErrors || !resource.getWarnings().isEmpty()) {
+            BasicDiagnostic basicDiagnostic =
+                new BasicDiagnostic
+                    (hasErrors ? Diagnostic.ERROR : Diagnostic.WARNING,
+                     "org.eclipse.lyo.tools.toolchain.editor",
+                     0,
+                     getString("_UI_CreateModelError_message", resource.getURI()),
+                     new Object [] { exception == null ? (Object)resource : exception });
+            basicDiagnostic.merge(EcoreUtil.computeDiagnostic(resource, true));
+            return basicDiagnostic;
+        }
+        else if (exception != null) {
+            return
+                new BasicDiagnostic
+                    (Diagnostic.ERROR,
+                     "org.eclipse.lyo.tools.toolchain.editor",
+                     0,
+                     getString("_UI_CreateModelError_message", resource.getURI()),
+                     new Object[] { exception });
+        }
+        else {
+            return Diagnostic.OK_INSTANCE;
+        }
+    }
 
 	/**
-	 * This is the method used by the framework to install your own controls.
-	 * <!-- begin-user-doc -->
+     * This is the method used by the framework to install your own controls.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void createPages() {
-		// Creates the model from the editor input
-		//
-		createModel();
+        // Creates the model from the editor input
+        //
+        createModel();
 
-		// Only creates the other pages if there is something that can be edited
-		//
-		if (!getEditingDomain().getResourceSet().getResources().isEmpty()) {
-			// Create a page for the selection tree view.
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							Tree tree = new Tree(composite, SWT.MULTI);
-							TreeViewer newTreeViewer = new TreeViewer(tree);
-							return newTreeViewer;
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
+        // Only creates the other pages if there is something that can be edited
+        //
+        if (!getEditingDomain().getResourceSet().getResources().isEmpty()) {
+            // Create a page for the selection tree view.
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            Tree tree = new Tree(composite, SWT.MULTI);
+                            TreeViewer newTreeViewer = new TreeViewer(tree);
+                            return newTreeViewer;
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
 
-				selectionViewer = (TreeViewer)viewerPane.getViewer();
-				selectionViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                selectionViewer = (TreeViewer)viewerPane.getViewer();
+                selectionViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                selectionViewer.setUseHashlookup(true);
 
-				selectionViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
-				selectionViewer.setInput(editingDomain.getResourceSet());
-				selectionViewer.setSelection(new StructuredSelection(editingDomain.getResourceSet().getResources().get(0)), true);
-				viewerPane.setTitle(editingDomain.getResourceSet());
+                selectionViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+                selectionViewer.setInput(editingDomain.getResourceSet());
+                selectionViewer.setSelection(new StructuredSelection(editingDomain.getResourceSet().getResources().get(0)), true);
+                viewerPane.setTitle(editingDomain.getResourceSet());
 
-				new AdapterFactoryTreeEditor(selectionViewer.getTree(), adapterFactory);
+                new AdapterFactoryTreeEditor(selectionViewer.getTree(), adapterFactory);
 
-				createContextMenuFor(selectionViewer);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_SelectionPage_label"));
-			}
+                createContextMenuFor(selectionViewer);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_SelectionPage_label"));
+            }
 
-			// Create a page for the parent tree view.
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							Tree tree = new Tree(composite, SWT.MULTI);
-							TreeViewer newTreeViewer = new TreeViewer(tree);
-							return newTreeViewer;
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
+            // Create a page for the parent tree view.
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            Tree tree = new Tree(composite, SWT.MULTI);
+                            TreeViewer newTreeViewer = new TreeViewer(tree);
+                            return newTreeViewer;
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
 
-				parentViewer = (TreeViewer)viewerPane.getViewer();
-				parentViewer.setAutoExpandLevel(30);
-				parentViewer.setContentProvider(new ReverseAdapterFactoryContentProvider(adapterFactory));
-				parentViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+                parentViewer = (TreeViewer)viewerPane.getViewer();
+                parentViewer.setAutoExpandLevel(30);
+                parentViewer.setContentProvider(new ReverseAdapterFactoryContentProvider(adapterFactory));
+                parentViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
 
-				createContextMenuFor(parentViewer);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_ParentPage_label"));
-			}
+                createContextMenuFor(parentViewer);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_ParentPage_label"));
+            }
 
-			// This is the page for the list viewer
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							return new ListViewer(composite);
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
-				listViewer = (ListViewer)viewerPane.getViewer();
-				listViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
-				listViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+            // This is the page for the list viewer
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            return new ListViewer(composite);
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
+                listViewer = (ListViewer)viewerPane.getViewer();
+                listViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                listViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
 
-				createContextMenuFor(listViewer);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_ListPage_label"));
-			}
+                createContextMenuFor(listViewer);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_ListPage_label"));
+            }
 
-			// This is the page for the tree viewer
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							return new TreeViewer(composite);
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
-				treeViewer = (TreeViewer)viewerPane.getViewer();
-				treeViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
-				treeViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+            // This is the page for the tree viewer
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            return new TreeViewer(composite);
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
+                treeViewer = (TreeViewer)viewerPane.getViewer();
+                treeViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                treeViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
 
-				new AdapterFactoryTreeEditor(treeViewer.getTree(), adapterFactory);
+                new AdapterFactoryTreeEditor(treeViewer.getTree(), adapterFactory);
 
-				createContextMenuFor(treeViewer);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_TreePage_label"));
-			}
+                createContextMenuFor(treeViewer);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_TreePage_label"));
+            }
 
-			// This is the page for the table viewer.
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							return new TableViewer(composite);
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
-				tableViewer = (TableViewer)viewerPane.getViewer();
+            // This is the page for the table viewer.
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            return new TableViewer(composite);
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
+                tableViewer = (TableViewer)viewerPane.getViewer();
 
-				Table table = tableViewer.getTable();
-				TableLayout layout = new TableLayout();
-				table.setLayout(layout);
-				table.setHeaderVisible(true);
-				table.setLinesVisible(true);
+                Table table = tableViewer.getTable();
+                TableLayout layout = new TableLayout();
+                table.setLayout(layout);
+                table.setHeaderVisible(true);
+                table.setLinesVisible(true);
 
-				TableColumn objectColumn = new TableColumn(table, SWT.NONE);
-				layout.addColumnData(new ColumnWeightData(3, 100, true));
-				objectColumn.setText(getString("_UI_ObjectColumn_label"));
-				objectColumn.setResizable(true);
+                TableColumn objectColumn = new TableColumn(table, SWT.NONE);
+                layout.addColumnData(new ColumnWeightData(3, 100, true));
+                objectColumn.setText(getString("_UI_ObjectColumn_label"));
+                objectColumn.setResizable(true);
 
-				TableColumn selfColumn = new TableColumn(table, SWT.NONE);
-				layout.addColumnData(new ColumnWeightData(2, 100, true));
-				selfColumn.setText(getString("_UI_SelfColumn_label"));
-				selfColumn.setResizable(true);
+                TableColumn selfColumn = new TableColumn(table, SWT.NONE);
+                layout.addColumnData(new ColumnWeightData(2, 100, true));
+                selfColumn.setText(getString("_UI_SelfColumn_label"));
+                selfColumn.setResizable(true);
 
-				tableViewer.setColumnProperties(new String [] {"a", "b"});
-				tableViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
-				tableViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+                tableViewer.setColumnProperties(new String [] {"a", "b"});
+                tableViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                tableViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
 
-				createContextMenuFor(tableViewer);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_TablePage_label"));
-			}
+                createContextMenuFor(tableViewer);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_TablePage_label"));
+            }
 
-			// This is the page for the table tree viewer.
-			//
-			{
-				ViewerPane viewerPane =
-					new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
-						@Override
-						public Viewer createViewer(Composite composite) {
-							return new TreeViewer(composite);
-						}
-						@Override
-						public void requestActivation() {
-							super.requestActivation();
-							setCurrentViewerPane(this);
-						}
-					};
-				viewerPane.createControl(getContainer());
+            // This is the page for the table tree viewer.
+            //
+            {
+                ViewerPane viewerPane =
+                    new ViewerPane(getSite().getPage(), ToolchainEditor.this) {
+                        @Override
+                        public Viewer createViewer(Composite composite) {
+                            return new TreeViewer(composite);
+                        }
+                        @Override
+                        public void requestActivation() {
+                            super.requestActivation();
+                            setCurrentViewerPane(this);
+                        }
+                    };
+                viewerPane.createControl(getContainer());
 
-				treeViewerWithColumns = (TreeViewer)viewerPane.getViewer();
+                treeViewerWithColumns = (TreeViewer)viewerPane.getViewer();
 
-				Tree tree = treeViewerWithColumns.getTree();
-				tree.setLayoutData(new FillLayout());
-				tree.setHeaderVisible(true);
-				tree.setLinesVisible(true);
+                Tree tree = treeViewerWithColumns.getTree();
+                tree.setLayoutData(new FillLayout());
+                tree.setHeaderVisible(true);
+                tree.setLinesVisible(true);
 
-				TreeColumn objectColumn = new TreeColumn(tree, SWT.NONE);
-				objectColumn.setText(getString("_UI_ObjectColumn_label"));
-				objectColumn.setResizable(true);
-				objectColumn.setWidth(250);
+                TreeColumn objectColumn = new TreeColumn(tree, SWT.NONE);
+                objectColumn.setText(getString("_UI_ObjectColumn_label"));
+                objectColumn.setResizable(true);
+                objectColumn.setWidth(250);
 
-				TreeColumn selfColumn = new TreeColumn(tree, SWT.NONE);
-				selfColumn.setText(getString("_UI_SelfColumn_label"));
-				selfColumn.setResizable(true);
-				selfColumn.setWidth(200);
+                TreeColumn selfColumn = new TreeColumn(tree, SWT.NONE);
+                selfColumn.setText(getString("_UI_SelfColumn_label"));
+                selfColumn.setResizable(true);
+                selfColumn.setWidth(200);
 
-				treeViewerWithColumns.setColumnProperties(new String [] {"a", "b"});
-				treeViewerWithColumns.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
-				treeViewerWithColumns.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+                treeViewerWithColumns.setColumnProperties(new String [] {"a", "b"});
+                treeViewerWithColumns.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                treeViewerWithColumns.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
 
-				createContextMenuFor(treeViewerWithColumns);
-				int pageIndex = addPage(viewerPane.getControl());
-				setPageText(pageIndex, getString("_UI_TreeWithColumnsPage_label"));
-			}
+                createContextMenuFor(treeViewerWithColumns);
+                int pageIndex = addPage(viewerPane.getControl());
+                setPageText(pageIndex, getString("_UI_TreeWithColumnsPage_label"));
+            }
 
-			getSite().getShell().getDisplay().asyncExec
-				(new Runnable() {
-					 public void run() {
-						 setActivePage(0);
-					 }
-				 });
-		}
+            getSite().getShell().getDisplay().asyncExec
+                (new Runnable() {
+                     public void run() {
+                         setActivePage(0);
+                     }
+                 });
+        }
 
-		// Ensures that this editor will only display the page's tab
-		// area if there are more than one page
-		//
-		getContainer().addControlListener
-			(new ControlAdapter() {
-				boolean guard = false;
-				@Override
-				public void controlResized(ControlEvent event) {
-					if (!guard) {
-						guard = true;
-						hideTabs();
-						guard = false;
-					}
-				}
-			 });
+        // Ensures that this editor will only display the page's tab
+        // area if there are more than one page
+        //
+        getContainer().addControlListener
+            (new ControlAdapter() {
+                boolean guard = false;
+                @Override
+                public void controlResized(ControlEvent event) {
+                    if (!guard) {
+                        guard = true;
+                        hideTabs();
+                        guard = false;
+                    }
+                }
+             });
 
-		getSite().getShell().getDisplay().asyncExec
-			(new Runnable() {
-				 public void run() {
-					 updateProblemIndication();
-				 }
-			 });
-	}
+        getSite().getShell().getDisplay().asyncExec
+            (new Runnable() {
+                 public void run() {
+                     updateProblemIndication();
+                 }
+             });
+    }
 
 	/**
-	 * If there is just one page in the multi-page editor part,
-	 * this hides the single tab at the bottom.
-	 * <!-- begin-user-doc -->
+     * If there is just one page in the multi-page editor part,
+     * this hides the single tab at the bottom.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void hideTabs() {
-		if (getPageCount() <= 1) {
-			setPageText(0, "");
-			if (getContainer() instanceof CTabFolder) {
-				((CTabFolder)getContainer()).setTabHeight(1);
-				Point point = getContainer().getSize();
-				getContainer().setSize(point.x, point.y + 6);
-			}
-		}
-	}
+        if (getPageCount() <= 1) {
+            setPageText(0, "");
+            if (getContainer() instanceof CTabFolder) {
+                ((CTabFolder)getContainer()).setTabHeight(1);
+                Point point = getContainer().getSize();
+                getContainer().setSize(point.x, point.y + 6);
+            }
+        }
+    }
 
 	/**
-	 * If there is more than one page in the multi-page editor part,
-	 * this shows the tabs at the bottom.
-	 * <!-- begin-user-doc -->
+     * If there is more than one page in the multi-page editor part,
+     * this shows the tabs at the bottom.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void showTabs() {
-		if (getPageCount() > 1) {
-			setPageText(0, getString("_UI_SelectionPage_label"));
-			if (getContainer() instanceof CTabFolder) {
-				((CTabFolder)getContainer()).setTabHeight(SWT.DEFAULT);
-				Point point = getContainer().getSize();
-				getContainer().setSize(point.x, point.y - 6);
-			}
-		}
-	}
+        if (getPageCount() > 1) {
+            setPageText(0, getString("_UI_SelectionPage_label"));
+            if (getContainer() instanceof CTabFolder) {
+                ((CTabFolder)getContainer()).setTabHeight(SWT.DEFAULT);
+                Point point = getContainer().getSize();
+                getContainer().setSize(point.x, point.y - 6);
+            }
+        }
+    }
 
 	/**
-	 * This is used to track the active viewer.
-	 * <!-- begin-user-doc -->
+     * This is used to track the active viewer.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	protected void pageChange(int pageIndex) {
-		super.pageChange(pageIndex);
+        super.pageChange(pageIndex);
 
-		if (contentOutlinePage != null) {
-			handleContentOutlineSelection(contentOutlinePage.getSelection());
-		}
-	}
+        if (contentOutlinePage != null) {
+            handleContentOutlineSelection(contentOutlinePage.getSelection());
+        }
+    }
 
 	/**
-	 * This is how the framework determines which interfaces we implement.
-	 * <!-- begin-user-doc -->
+     * This is how the framework determines which interfaces we implement.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Object getAdapter(Class key) {
-		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
-		}
-		else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
-		}
-		else if (key.equals(IGotoMarker.class)) {
-			return this;
-		}
-		else {
-			return super.getAdapter(key);
-		}
-	}
+        if (key.equals(IContentOutlinePage.class)) {
+            return showOutlineView() ? getContentOutlinePage() : null;
+        }
+        else if (key.equals(IPropertySheetPage.class)) {
+            return getPropertySheetPage();
+        }
+        else if (key.equals(IGotoMarker.class)) {
+            return this;
+        }
+        else {
+            return super.getAdapter(key);
+        }
+    }
 
 	/**
-	 * This accesses a cached version of the content outliner.
-	 * <!-- begin-user-doc -->
+     * This accesses a cached version of the content outliner.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public IContentOutlinePage getContentOutlinePage() {
-		if (contentOutlinePage == null) {
-			// The content outline is just a tree.
-			//
-			class MyContentOutlinePage extends ContentOutlinePage {
-				@Override
-				public void createControl(Composite parent) {
-					super.createControl(parent);
-					contentOutlineViewer = getTreeViewer();
-					contentOutlineViewer.addSelectionChangedListener(this);
+        if (contentOutlinePage == null) {
+            // The content outline is just a tree.
+            //
+            class MyContentOutlinePage extends ContentOutlinePage {
+                @Override
+                public void createControl(Composite parent) {
+                    super.createControl(parent);
+                    contentOutlineViewer = getTreeViewer();
+                    contentOutlineViewer.addSelectionChangedListener(this);
 
-					// Set up the tree viewer.
-					//
-					contentOutlineViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
-					contentOutlineViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
-					contentOutlineViewer.setInput(editingDomain.getResourceSet());
+                    // Set up the tree viewer.
+                    //
+                    contentOutlineViewer.setUseHashlookup(true);
+                    contentOutlineViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                    contentOutlineViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
+                    contentOutlineViewer.setInput(editingDomain.getResourceSet());
 
-					// Make sure our popups work.
-					//
-					createContextMenuFor(contentOutlineViewer);
+                    // Make sure our popups work.
+                    //
+                    createContextMenuFor(contentOutlineViewer);
 
-					if (!editingDomain.getResourceSet().getResources().isEmpty()) {
-					  // Select the root object in the view.
-					  //
-					  contentOutlineViewer.setSelection(new StructuredSelection(editingDomain.getResourceSet().getResources().get(0)), true);
-					}
-				}
+                    if (!editingDomain.getResourceSet().getResources().isEmpty()) {
+                      // Select the root object in the view.
+                      //
+                      contentOutlineViewer.setSelection(new StructuredSelection(editingDomain.getResourceSet().getResources().get(0)), true);
+                    }
+                }
 
-				@Override
-				public void makeContributions(IMenuManager menuManager, IToolBarManager toolBarManager, IStatusLineManager statusLineManager) {
-					super.makeContributions(menuManager, toolBarManager, statusLineManager);
-					contentOutlineStatusLineManager = statusLineManager;
-				}
+                @Override
+                public void makeContributions(IMenuManager menuManager, IToolBarManager toolBarManager, IStatusLineManager statusLineManager) {
+                    super.makeContributions(menuManager, toolBarManager, statusLineManager);
+                    contentOutlineStatusLineManager = statusLineManager;
+                }
 
-				@Override
-				public void setActionBars(IActionBars actionBars) {
-					super.setActionBars(actionBars);
-					getActionBarContributor().shareGlobalActions(this, actionBars);
-				}
-			}
+                @Override
+                public void setActionBars(IActionBars actionBars) {
+                    super.setActionBars(actionBars);
+                    getActionBarContributor().shareGlobalActions(this, actionBars);
+                }
+            }
 
-			contentOutlinePage = new MyContentOutlinePage();
+            contentOutlinePage = new MyContentOutlinePage();
 
-			// Listen to selection so that we can handle it is a special way.
-			//
-			contentOutlinePage.addSelectionChangedListener
-				(new ISelectionChangedListener() {
-					 // This ensures that we handle selections correctly.
-					 //
-					 public void selectionChanged(SelectionChangedEvent event) {
-						 handleContentOutlineSelection(event.getSelection());
-					 }
-				 });
-		}
+            // Listen to selection so that we can handle it is a special way.
+            //
+            contentOutlinePage.addSelectionChangedListener
+                (new ISelectionChangedListener() {
+                     // This ensures that we handle selections correctly.
+                     //
+                     public void selectionChanged(SelectionChangedEvent event) {
+                         handleContentOutlineSelection(event.getSelection());
+                     }
+                 });
+        }
 
-		return contentOutlinePage;
-	}
+        return contentOutlinePage;
+    }
 
 	/**
-	 * This accesses a cached version of the property sheet.
-	 * <!-- begin-user-doc -->
+     * This accesses a cached version of the property sheet.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public IPropertySheetPage getPropertySheetPage() {
-		PropertySheetPage propertySheetPage =
-			new ExtendedPropertySheetPage(editingDomain) {
-				@Override
-				public void setSelectionToViewer(List<?> selection) {
-					ToolchainEditor.this.setSelectionToViewer(selection);
-					ToolchainEditor.this.setFocus();
-				}
+        PropertySheetPage propertySheetPage =
+            new ExtendedPropertySheetPage(editingDomain) {
+                @Override
+                public void setSelectionToViewer(List<?> selection) {
+                    ToolchainEditor.this.setSelectionToViewer(selection);
+                    ToolchainEditor.this.setFocus();
+                }
 
-				@Override
-				public void setActionBars(IActionBars actionBars) {
-					super.setActionBars(actionBars);
-					getActionBarContributor().shareGlobalActions(this, actionBars);
-				}
-			};
-		propertySheetPage.setPropertySourceProvider(new AdapterFactoryContentProvider(adapterFactory));
-		propertySheetPages.add(propertySheetPage);
+                @Override
+                public void setActionBars(IActionBars actionBars) {
+                    super.setActionBars(actionBars);
+                    getActionBarContributor().shareGlobalActions(this, actionBars);
+                }
+            };
+        propertySheetPage.setPropertySourceProvider(new AdapterFactoryContentProvider(adapterFactory));
+        propertySheetPages.add(propertySheetPage);
 
-		return propertySheetPage;
-	}
+        return propertySheetPage;
+    }
 
 	/**
-	 * This deals with how we want selection in the outliner to affect the other views.
-	 * <!-- begin-user-doc -->
+     * This deals with how we want selection in the outliner to affect the other views.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void handleContentOutlineSelection(ISelection selection) {
-		if (currentViewerPane != null && !selection.isEmpty() && selection instanceof IStructuredSelection) {
-			Iterator<?> selectedElements = ((IStructuredSelection)selection).iterator();
-			if (selectedElements.hasNext()) {
-				// Get the first selected element.
-				//
-				Object selectedElement = selectedElements.next();
+        if (currentViewerPane != null && !selection.isEmpty() && selection instanceof IStructuredSelection) {
+            Iterator<?> selectedElements = ((IStructuredSelection)selection).iterator();
+            if (selectedElements.hasNext()) {
+                // Get the first selected element.
+                //
+                Object selectedElement = selectedElements.next();
 
-				// If it's the selection viewer, then we want it to select the same selection as this selection.
-				//
-				if (currentViewerPane.getViewer() == selectionViewer) {
-					ArrayList<Object> selectionList = new ArrayList<Object>();
-					selectionList.add(selectedElement);
-					while (selectedElements.hasNext()) {
-						selectionList.add(selectedElements.next());
-					}
+                // If it's the selection viewer, then we want it to select the same selection as this selection.
+                //
+                if (currentViewerPane.getViewer() == selectionViewer) {
+                    ArrayList<Object> selectionList = new ArrayList<Object>();
+                    selectionList.add(selectedElement);
+                    while (selectedElements.hasNext()) {
+                        selectionList.add(selectedElements.next());
+                    }
 
-					// Set the selection to the widget.
-					//
-					selectionViewer.setSelection(new StructuredSelection(selectionList));
-				}
-				else {
-					// Set the input to the widget.
-					//
-					if (currentViewerPane.getViewer().getInput() != selectedElement) {
-						currentViewerPane.getViewer().setInput(selectedElement);
-						currentViewerPane.setTitle(selectedElement);
-					}
-				}
-			}
-		}
-	}
+                    // Set the selection to the widget.
+                    //
+                    selectionViewer.setSelection(new StructuredSelection(selectionList));
+                }
+                else {
+                    // Set the input to the widget.
+                    //
+                    if (currentViewerPane.getViewer().getInput() != selectedElement) {
+                        currentViewerPane.getViewer().setInput(selectedElement);
+                        currentViewerPane.setTitle(selectedElement);
+                    }
+                }
+            }
+        }
+    }
 
 	/**
-	 * This is for implementing {@link IEditorPart} and simply tests the command stack.
-	 * <!-- begin-user-doc -->
+     * This is for implementing {@link IEditorPart} and simply tests the command stack.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public boolean isDirty() {
-		return ((BasicCommandStack)editingDomain.getCommandStack()).isSaveNeeded();
-	}
+        return ((BasicCommandStack)editingDomain.getCommandStack()).isSaveNeeded();
+    }
 
 	/**
-	 * This is for implementing {@link IEditorPart} and simply saves the model file.
-	 * <!-- begin-user-doc -->
+     * This is for implementing {@link IEditorPart} and simply saves the model file.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void doSave(IProgressMonitor progressMonitor) {
-		// Save only resources that have actually changed.
-		//
-		final Map<Object, Object> saveOptions = new HashMap<Object, Object>();
-		saveOptions.put(Resource.OPTION_SAVE_ONLY_IF_CHANGED, Resource.OPTION_SAVE_ONLY_IF_CHANGED_MEMORY_BUFFER);
-		saveOptions.put(Resource.OPTION_LINE_DELIMITER, Resource.OPTION_LINE_DELIMITER_UNSPECIFIED);
+        // Save only resources that have actually changed.
+        //
+        final Map<Object, Object> saveOptions = new HashMap<Object, Object>();
+        saveOptions.put(Resource.OPTION_SAVE_ONLY_IF_CHANGED, Resource.OPTION_SAVE_ONLY_IF_CHANGED_MEMORY_BUFFER);
+        saveOptions.put(Resource.OPTION_LINE_DELIMITER, Resource.OPTION_LINE_DELIMITER_UNSPECIFIED);
 
-		// Do the work within an operation because this is a long running activity that modifies the workbench.
-		//
-		WorkspaceModifyOperation operation =
-			new WorkspaceModifyOperation() {
-				// This is the method that gets invoked when the operation runs.
-				//
-				@Override
-				public void execute(IProgressMonitor monitor) {
-					// Save the resources to the file system.
-					//
-					boolean first = true;
-					for (Resource resource : editingDomain.getResourceSet().getResources()) {
-						if ((first || !resource.getContents().isEmpty() || isPersisted(resource)) && !editingDomain.isReadOnly(resource)) {
-							try {
-								long timeStamp = resource.getTimeStamp();
-								resource.save(saveOptions);
-								if (resource.getTimeStamp() != timeStamp) {
-									savedResources.add(resource);
-								}
-							}
-							catch (Exception exception) {
-								resourceToDiagnosticMap.put(resource, analyzeResourceProblems(resource, exception));
-							}
-							first = false;
-						}
-					}
-				}
-			};
+        // Do the work within an operation because this is a long running activity that modifies the workbench.
+        //
+        WorkspaceModifyOperation operation =
+            new WorkspaceModifyOperation() {
+                // This is the method that gets invoked when the operation runs.
+                //
+                @Override
+                public void execute(IProgressMonitor monitor) {
+                    // Save the resources to the file system.
+                    //
+                    boolean first = true;
+                    List<Resource> resources = editingDomain.getResourceSet().getResources();
+                    for (int i = 0; i < resources.size(); ++i) {
+                        Resource resource = resources.get(i);
+                        if ((first || !resource.getContents().isEmpty() || isPersisted(resource)) && !editingDomain.isReadOnly(resource)) {
+                            try {
+                                long timeStamp = resource.getTimeStamp();
+                                resource.save(saveOptions);
+                                if (resource.getTimeStamp() != timeStamp) {
+                                    savedResources.add(resource);
+                                }
+                            }
+                            catch (Exception exception) {
+                                resourceToDiagnosticMap.put(resource, analyzeResourceProblems(resource, exception));
+                            }
+                            first = false;
+                        }
+                    }
+                }
+            };
 
-		updateProblemIndication = false;
-		try {
-			// This runs the options, and shows progress.
-			//
-			new ProgressMonitorDialog(getSite().getShell()).run(true, false, operation);
+        updateProblemIndication = false;
+        try {
+            // This runs the options, and shows progress.
+            //
+            new ProgressMonitorDialog(getSite().getShell()).run(true, false, operation);
 
-			// Refresh the necessary state.
-			//
-			((BasicCommandStack)editingDomain.getCommandStack()).saveIsDone();
-			firePropertyChange(IEditorPart.PROP_DIRTY);
-		}
-		catch (Exception exception) {
-			// Something went wrong that shouldn't.
-			//
-			ToolchainEditorPlugin.INSTANCE.log(exception);
-		}
-		updateProblemIndication = true;
-		updateProblemIndication();
-	}
+            // Refresh the necessary state.
+            //
+            ((BasicCommandStack)editingDomain.getCommandStack()).saveIsDone();
+            firePropertyChange(IEditorPart.PROP_DIRTY);
+        }
+        catch (Exception exception) {
+            // Something went wrong that shouldn't.
+            //
+            ToolchainEditorPlugin.INSTANCE.log(exception);
+        }
+        updateProblemIndication = true;
+        updateProblemIndication();
+    }
 
 	/**
-	 * This returns whether something has been persisted to the URI of the specified resource.
-	 * The implementation uses the URI converter from the editor's resource set to try to open an input stream.
-	 * <!-- begin-user-doc -->
+     * This returns whether something has been persisted to the URI of the specified resource.
+     * The implementation uses the URI converter from the editor's resource set to try to open an input stream.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected boolean isPersisted(Resource resource) {
-		boolean result = false;
-		try {
-			InputStream stream = editingDomain.getResourceSet().getURIConverter().createInputStream(resource.getURI());
-			if (stream != null) {
-				result = true;
-				stream.close();
-			}
-		}
-		catch (IOException e) {
-			// Ignore
-		}
-		return result;
-	}
+        boolean result = false;
+        try {
+            InputStream stream = editingDomain.getResourceSet().getURIConverter().createInputStream(resource.getURI());
+            if (stream != null) {
+                result = true;
+                stream.close();
+            }
+        }
+        catch (IOException e) {
+            // Ignore
+        }
+        return result;
+    }
 
 	/**
-	 * This always returns true because it is not currently supported.
-	 * <!-- begin-user-doc -->
+     * This always returns true because it is not currently supported.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public boolean isSaveAsAllowed() {
-		return true;
-	}
+        return true;
+    }
 
 	/**
-	 * This also changes the editor's input.
-	 * <!-- begin-user-doc -->
+     * This also changes the editor's input.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void doSaveAs() {
-		SaveAsDialog saveAsDialog = new SaveAsDialog(getSite().getShell());
-		saveAsDialog.open();
-		IPath path = saveAsDialog.getResult();
-		if (path != null) {
-			IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
-			if (file != null) {
-				doSaveAs(URI.createPlatformResourceURI(file.getFullPath().toString(), true), new FileEditorInput(file));
-			}
-		}
-	}
+        SaveAsDialog saveAsDialog = new SaveAsDialog(getSite().getShell());
+        saveAsDialog.open();
+        IPath path = saveAsDialog.getResult();
+        if (path != null) {
+            IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+            if (file != null) {
+                doSaveAs(URI.createPlatformResourceURI(file.getFullPath().toString(), true), new FileEditorInput(file));
+            }
+        }
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected void doSaveAs(URI uri, IEditorInput editorInput) {
-		(editingDomain.getResourceSet().getResources().get(0)).setURI(uri);
-		setInputWithNotify(editorInput);
-		setPartName(editorInput.getName());
-		IProgressMonitor progressMonitor =
-			getActionBars().getStatusLineManager() != null ?
-				getActionBars().getStatusLineManager().getProgressMonitor() :
-				new NullProgressMonitor();
-		doSave(progressMonitor);
-	}
+        (editingDomain.getResourceSet().getResources().get(0)).setURI(uri);
+        setInputWithNotify(editorInput);
+        setPartName(editorInput.getName());
+        IProgressMonitor progressMonitor =
+            getActionBars().getStatusLineManager() != null ?
+                getActionBars().getStatusLineManager().getProgressMonitor() :
+                new NullProgressMonitor();
+        doSave(progressMonitor);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void gotoMarker(IMarker marker) {
-		List<?> targetObjects = markerHelper.getTargetObjects(editingDomain, marker);
-		if (!targetObjects.isEmpty()) {
-			setSelectionToViewer(targetObjects);
-		}
-	}
+        List<?> targetObjects = markerHelper.getTargetObjects(editingDomain, marker);
+        if (!targetObjects.isEmpty()) {
+            setSelectionToViewer(targetObjects);
+        }
+    }
 
 	/**
-	 * This is called during startup.
-	 * <!-- begin-user-doc -->
+     * This is called during startup.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void init(IEditorSite site, IEditorInput editorInput) {
-		setSite(site);
-		setInputWithNotify(editorInput);
-		setPartName(editorInput.getName());
-		site.setSelectionProvider(this);
-		site.getPage().addPartListener(partListener);
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.POST_CHANGE);
-	}
+        setSite(site);
+        setInputWithNotify(editorInput);
+        setPartName(editorInput.getName());
+        site.setSelectionProvider(this);
+        site.getPage().addPartListener(partListener);
+        ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceChangeListener, IResourceChangeEvent.POST_CHANGE);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void setFocus() {
-		if (currentViewerPane != null) {
-			currentViewerPane.setFocus();
-		}
-		else {
-			getControl(getActivePage()).setFocus();
-		}
-	}
+        if (currentViewerPane != null) {
+            currentViewerPane.setFocus();
+        }
+        else {
+            getControl(getActivePage()).setFocus();
+        }
+    }
 
 	/**
-	 * This implements {@link org.eclipse.jface.viewers.ISelectionProvider}.
-	 * <!-- begin-user-doc -->
+     * This implements {@link org.eclipse.jface.viewers.ISelectionProvider}.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void addSelectionChangedListener(ISelectionChangedListener listener) {
-		selectionChangedListeners.add(listener);
-	}
+        selectionChangedListeners.add(listener);
+    }
 
 	/**
-	 * This implements {@link org.eclipse.jface.viewers.ISelectionProvider}.
-	 * <!-- begin-user-doc -->
+     * This implements {@link org.eclipse.jface.viewers.ISelectionProvider}.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
-		selectionChangedListeners.remove(listener);
-	}
+        selectionChangedListeners.remove(listener);
+    }
 
 	/**
-	 * This implements {@link org.eclipse.jface.viewers.ISelectionProvider} to return this editor's overall selection.
-	 * <!-- begin-user-doc -->
+     * This implements {@link org.eclipse.jface.viewers.ISelectionProvider} to return this editor's overall selection.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public ISelection getSelection() {
-		return editorSelection;
-	}
+        return editorSelection;
+    }
 
 	/**
-	 * This implements {@link org.eclipse.jface.viewers.ISelectionProvider} to set this editor's overall selection.
-	 * Calling this result will notify the listeners.
-	 * <!-- begin-user-doc -->
+     * This implements {@link org.eclipse.jface.viewers.ISelectionProvider} to set this editor's overall selection.
+     * Calling this result will notify the listeners.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void setSelection(ISelection selection) {
-		editorSelection = selection;
+        editorSelection = selection;
 
-		for (ISelectionChangedListener listener : selectionChangedListeners) {
-			listener.selectionChanged(new SelectionChangedEvent(this, selection));
-		}
-		setStatusLineManager(selection);
-	}
+        for (ISelectionChangedListener listener : selectionChangedListeners) {
+            listener.selectionChanged(new SelectionChangedEvent(this, selection));
+        }
+        setStatusLineManager(selection);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void setStatusLineManager(ISelection selection) {
-		IStatusLineManager statusLineManager = currentViewer != null && currentViewer == contentOutlineViewer ?
-			contentOutlineStatusLineManager : getActionBars().getStatusLineManager();
+        IStatusLineManager statusLineManager = currentViewer != null && currentViewer == contentOutlineViewer ?
+            contentOutlineStatusLineManager : getActionBars().getStatusLineManager();
 
-		if (statusLineManager != null) {
-			if (selection instanceof IStructuredSelection) {
-				Collection<?> collection = ((IStructuredSelection)selection).toList();
-				switch (collection.size()) {
-					case 0: {
-						statusLineManager.setMessage(getString("_UI_NoObjectSelected"));
-						break;
-					}
-					case 1: {
-						String text = new AdapterFactoryItemDelegator(adapterFactory).getText(collection.iterator().next());
-						statusLineManager.setMessage(getString("_UI_SingleObjectSelected", text));
-						break;
-					}
-					default: {
-						statusLineManager.setMessage(getString("_UI_MultiObjectSelected", Integer.toString(collection.size())));
-						break;
-					}
-				}
-			}
-			else {
-				statusLineManager.setMessage("");
-			}
-		}
-	}
+        if (statusLineManager != null) {
+            if (selection instanceof IStructuredSelection) {
+                Collection<?> collection = ((IStructuredSelection)selection).toList();
+                switch (collection.size()) {
+                    case 0: {
+                        statusLineManager.setMessage(getString("_UI_NoObjectSelected"));
+                        break;
+                    }
+                    case 1: {
+                        String text = new AdapterFactoryItemDelegator(adapterFactory).getText(collection.iterator().next());
+                        statusLineManager.setMessage(getString("_UI_SingleObjectSelected", text));
+                        break;
+                    }
+                    default: {
+                        statusLineManager.setMessage(getString("_UI_MultiObjectSelected", Integer.toString(collection.size())));
+                        break;
+                    }
+                }
+            }
+            else {
+                statusLineManager.setMessage("");
+            }
+        }
+    }
 
 	/**
-	 * This looks up a string in the plugin's plugin.properties file.
-	 * <!-- begin-user-doc -->
+     * This looks up a string in the plugin's plugin.properties file.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private static String getString(String key) {
-		return ToolchainEditorPlugin.INSTANCE.getString(key);
-	}
+        return ToolchainEditorPlugin.INSTANCE.getString(key);
+    }
 
 	/**
-	 * This looks up a string in plugin.properties, making a substitution.
-	 * <!-- begin-user-doc -->
+     * This looks up a string in plugin.properties, making a substitution.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private static String getString(String key, Object s1) {
-		return ToolchainEditorPlugin.INSTANCE.getString(key, new Object [] { s1 });
-	}
+        return ToolchainEditorPlugin.INSTANCE.getString(key, new Object [] { s1 });
+    }
 
 	/**
-	 * This implements {@link org.eclipse.jface.action.IMenuListener} to help fill the context menus with contributions from the Edit menu.
-	 * <!-- begin-user-doc -->
+     * This implements {@link org.eclipse.jface.action.IMenuListener} to help fill the context menus with contributions from the Edit menu.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void menuAboutToShow(IMenuManager menuManager) {
-		((IMenuListener)getEditorSite().getActionBarContributor()).menuAboutToShow(menuManager);
-	}
+        ((IMenuListener)getEditorSite().getActionBarContributor()).menuAboutToShow(menuManager);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EditingDomainActionBarContributor getActionBarContributor() {
-		return (EditingDomainActionBarContributor)getEditorSite().getActionBarContributor();
-	}
+        return (EditingDomainActionBarContributor)getEditorSite().getActionBarContributor();
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public IActionBars getActionBars() {
-		return getActionBarContributor().getActionBars();
-	}
+        return getActionBarContributor().getActionBars();
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public AdapterFactory getAdapterFactory() {
-		return adapterFactory;
-	}
+        return adapterFactory;
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	@Override
 	public void dispose() {
-		updateProblemIndication = false;
+        updateProblemIndication = false;
 
-		ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
+        ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
 
-		getSite().getPage().removePartListener(partListener);
+        getSite().getPage().removePartListener(partListener);
 
-		adapterFactory.dispose();
+        adapterFactory.dispose();
 
-		if (getActionBarContributor().getActiveEditor() == this) {
-			getActionBarContributor().setActiveEditor(null);
-		}
+        if (getActionBarContributor().getActiveEditor() == this) {
+            getActionBarContributor().setActiveEditor(null);
+        }
 
-		for (PropertySheetPage propertySheetPage : propertySheetPages) {
-			propertySheetPage.dispose();
-		}
+        for (PropertySheetPage propertySheetPage : propertySheetPages) {
+            propertySheetPage.dispose();
+        }
 
-		if (contentOutlinePage != null) {
-			contentOutlinePage.dispose();
-		}
+        if (contentOutlinePage != null) {
+            contentOutlinePage.dispose();
+        }
 
-		super.dispose();
-	}
+        super.dispose();
+    }
 
 	/**
-	 * Returns whether the outline view should be presented to the user.
-	 * <!-- begin-user-doc -->
+     * Returns whether the outline view should be presented to the user.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	protected boolean showOutlineView() {
-		return true;
-	}
+        return true;
+    }
 }

--- a/org.eclipse.lyo.tools.toolchain.model/src/toolchain/impl/ToolchainPackageImpl.java
+++ b/org.eclipse.lyo.tools.toolchain.model/src/toolchain/impl/ToolchainPackageImpl.java
@@ -24,198 +24,199 @@ import vocabulary.VocabularyPackage;
  */
 public class ToolchainPackageImpl extends EPackageImpl implements ToolchainPackage {
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private EClass toolchainEClass = null;
 
 	/**
-	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
+     * Creates an instance of the model <b>Package</b>, registered with
+     * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
+     * package URI value.
+     * <p>Note: the correct way to create the package is via the static
+     * factory method {@link #init init()}, which also performs
+     * initialization of the package, or returns the registered package,
+     * if one already exists.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see org.eclipse.emf.ecore.EPackage.Registry
-	 * @see toolchain.ToolchainPackage#eNS_URI
-	 * @see #init()
-	 * @generated
-	 */
+     * @see org.eclipse.emf.ecore.EPackage.Registry
+     * @see toolchain.ToolchainPackage#eNS_URI
+     * @see #init()
+     * @generated
+     */
 	private ToolchainPackageImpl() {
-		super(eNS_URI, ToolchainFactory.eINSTANCE);
-	}
+        super(eNS_URI, ToolchainFactory.eINSTANCE);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-	 * 
-	 * <p>This method is used to initialize {@link ToolchainPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
+     * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+     * 
+     * <p>This method is used to initialize {@link ToolchainPackage#eINSTANCE} when that field is accessed.
+     * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #eNS_URI
-	 * @see #createPackageContents()
-	 * @see #initializePackageContents()
-	 * @generated
-	 */
+     * @see #eNS_URI
+     * @see #createPackageContents()
+     * @see #initializePackageContents()
+     * @generated
+     */
 	public static ToolchainPackage init() {
-		if (isInited) return (ToolchainPackage)EPackage.Registry.INSTANCE.getEPackage(ToolchainPackage.eNS_URI);
+        if (isInited) return (ToolchainPackage)EPackage.Registry.INSTANCE.getEPackage(ToolchainPackage.eNS_URI);
 
-		// Obtain or create and register package
-		ToolchainPackageImpl theToolchainPackage = (ToolchainPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof ToolchainPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new ToolchainPackageImpl());
+        // Obtain or create and register package
+        ToolchainPackageImpl theToolchainPackage = (ToolchainPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof ToolchainPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new ToolchainPackageImpl());
 
-		isInited = true;
+        isInited = true;
 
-		// Initialize simple dependencies
-		AdaptorinterfacePackage.eINSTANCE.eClass();
+        // Initialize simple dependencies
+        AdaptorinterfacePackage.eINSTANCE.eClass();
+        VocabularyPackage.eINSTANCE.eClass();
 
-		// Create package meta-data objects
-		theToolchainPackage.createPackageContents();
+        // Create package meta-data objects
+        theToolchainPackage.createPackageContents();
 
-		// Initialize created meta-data
-		theToolchainPackage.initializePackageContents();
+        // Initialize created meta-data
+        theToolchainPackage.initializePackageContents();
 
-		// Mark meta-data to indicate it can't be changed
-		theToolchainPackage.freeze();
+        // Mark meta-data to indicate it can't be changed
+        theToolchainPackage.freeze();
 
   
-		// Update the registry and return the package
-		EPackage.Registry.INSTANCE.put(ToolchainPackage.eNS_URI, theToolchainPackage);
-		return theToolchainPackage;
-	}
+        // Update the registry and return the package
+        EPackage.Registry.INSTANCE.put(ToolchainPackage.eNS_URI, theToolchainPackage);
+        return theToolchainPackage;
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EClass getToolchain() {
-		return toolchainEClass;
-	}
+        return toolchainEClass;
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EAttribute getToolchain_Name() {
-		return (EAttribute)toolchainEClass.getEStructuralFeatures().get(0);
-	}
+        return (EAttribute)toolchainEClass.getEStructuralFeatures().get(0);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EReference getToolchain_AdaptorInterfaces() {
-		return (EReference)toolchainEClass.getEStructuralFeatures().get(1);
-	}
+        return (EReference)toolchainEClass.getEStructuralFeatures().get(1);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EReference getToolchain_Specification() {
-		return (EReference)toolchainEClass.getEStructuralFeatures().get(2);
-	}
+        return (EReference)toolchainEClass.getEStructuralFeatures().get(2);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public EReference getToolchain_Vocabularies() {
-		return (EReference)toolchainEClass.getEStructuralFeatures().get(3);
-	}
+        return (EReference)toolchainEClass.getEStructuralFeatures().get(3);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public ToolchainFactory getToolchainFactory() {
-		return (ToolchainFactory)getEFactoryInstance();
-	}
+        return (ToolchainFactory)getEFactoryInstance();
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
+     * Creates the meta-model objects for the package.  This method is
+     * guarded to have no affect on any invocation but its first.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void createPackageContents() {
-		if (isCreated) return;
-		isCreated = true;
+        if (isCreated) return;
+        isCreated = true;
 
-		// Create classes and their features
-		toolchainEClass = createEClass(TOOLCHAIN);
-		createEAttribute(toolchainEClass, TOOLCHAIN__NAME);
-		createEReference(toolchainEClass, TOOLCHAIN__ADAPTOR_INTERFACES);
-		createEReference(toolchainEClass, TOOLCHAIN__SPECIFICATION);
-		createEReference(toolchainEClass, TOOLCHAIN__VOCABULARIES);
-	}
+        // Create classes and their features
+        toolchainEClass = createEClass(TOOLCHAIN);
+        createEAttribute(toolchainEClass, TOOLCHAIN__NAME);
+        createEReference(toolchainEClass, TOOLCHAIN__ADAPTOR_INTERFACES);
+        createEReference(toolchainEClass, TOOLCHAIN__SPECIFICATION);
+        createEReference(toolchainEClass, TOOLCHAIN__VOCABULARIES);
+    }
 
 	/**
-	 * <!-- begin-user-doc -->
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
+     * Complete the initialization of the package and its meta-model.  This
+     * method is guarded to have no affect on any invocation but its first.
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @generated
-	 */
+     * @generated
+     */
 	public void initializePackageContents() {
-		if (isInitialized) return;
-		isInitialized = true;
+        if (isInitialized) return;
+        isInitialized = true;
 
-		// Initialize package
-		setName(eNAME);
-		setNsPrefix(eNS_PREFIX);
-		setNsURI(eNS_URI);
+        // Initialize package
+        setName(eNAME);
+        setNsPrefix(eNS_PREFIX);
+        setNsURI(eNS_URI);
 
-		// Obtain other dependent packages
-		AdaptorinterfacePackage theAdaptorinterfacePackage = (AdaptorinterfacePackage)EPackage.Registry.INSTANCE.getEPackage(AdaptorinterfacePackage.eNS_URI);
-		VocabularyPackage theVocabularyPackage = (VocabularyPackage)EPackage.Registry.INSTANCE.getEPackage(VocabularyPackage.eNS_URI);
+        // Obtain other dependent packages
+        AdaptorinterfacePackage theAdaptorinterfacePackage = (AdaptorinterfacePackage)EPackage.Registry.INSTANCE.getEPackage(AdaptorinterfacePackage.eNS_URI);
+        VocabularyPackage theVocabularyPackage = (VocabularyPackage)EPackage.Registry.INSTANCE.getEPackage(VocabularyPackage.eNS_URI);
 
-		// Create type parameters
+        // Create type parameters
 
-		// Set bounds for type parameters
+        // Set bounds for type parameters
 
-		// Add supertypes to classes
+        // Add supertypes to classes
 
-		// Initialize classes, features, and operations; add parameters
-		initEClass(toolchainEClass, Toolchain.class, "Toolchain", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(getToolchain_Name(), ecorePackage.getEString(), "name", "New ToolChain", 0, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getToolchain_AdaptorInterfaces(), theAdaptorinterfacePackage.getAdaptorInterface(), null, "adaptorInterfaces", null, 0, -1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getToolchain_Specification(), theAdaptorinterfacePackage.getSpecification(), null, "specification", null, 1, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getToolchain_Vocabularies(), theVocabularyPackage.getVocabularies(), null, "vocabularies", null, 1, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        // Initialize classes, features, and operations; add parameters
+        initEClass(toolchainEClass, Toolchain.class, "Toolchain", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+        initEAttribute(getToolchain_Name(), ecorePackage.getEString(), "name", "New ToolChain", 0, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEReference(getToolchain_AdaptorInterfaces(), theAdaptorinterfacePackage.getAdaptorInterface(), null, "adaptorInterfaces", null, 0, -1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEReference(getToolchain_Specification(), theAdaptorinterfacePackage.getSpecification(), null, "specification", null, 1, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEReference(getToolchain_Vocabularies(), theVocabularyPackage.getVocabularies(), null, "vocabularies", null, 1, 1, Toolchain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		// Create resource
-		createResource(eNS_URI);
-	}
+        // Create resource
+        createResource(eNS_URI);
+    }
 
 } //ToolchainPackageImpl

--- a/org.eclipse.lyo.tools.vocabulary.editor/src/vocabulary/presentation/VocabularyEditor.java
+++ b/org.eclipse.lyo.tools.vocabulary.editor/src/vocabulary/presentation/VocabularyEditor.java
@@ -404,6 +404,8 @@ public class VocabularyEditor
      */
     protected EContentAdapter problemIndicationAdapter =
         new EContentAdapter() {
+            protected boolean dispatching;
+
             @Override
             public void notifyChanged(Notification notification) {
                 if (notification.getNotifier() instanceof Resource) {
@@ -419,21 +421,26 @@ public class VocabularyEditor
                             else {
                                 resourceToDiagnosticMap.remove(resource);
                             }
-
-                            if (updateProblemIndication) {
-                                getSite().getShell().getDisplay().asyncExec
-                                    (new Runnable() {
-                                         public void run() {
-                                             updateProblemIndication();
-                                         }
-                                     });
-                            }
+                            dispatchUpdateProblemIndication();
                             break;
                         }
                     }
                 }
                 else {
                     super.notifyChanged(notification);
+                }
+            }
+
+            protected void dispatchUpdateProblemIndication() {
+                if (updateProblemIndication && !dispatching) {
+                    dispatching = true;
+                    getSite().getShell().getDisplay().asyncExec
+                        (new Runnable() {
+                             public void run() {
+                                 dispatching = false;
+                                 updateProblemIndication();
+                             }
+                         });
                 }
             }
 
@@ -446,14 +453,7 @@ public class VocabularyEditor
             protected void unsetTarget(Resource target) {
                 basicUnsetTarget(target);
                 resourceToDiagnosticMap.remove(target);
-                if (updateProblemIndication) {
-                    getSite().getShell().getDisplay().asyncExec
-                        (new Runnable() {
-                             public void run() {
-                                 updateProblemIndication();
-                             }
-                         });
-                }
+                dispatchUpdateProblemIndication();
             }
         };
 
@@ -651,14 +651,11 @@ public class VocabularyEditor
             }
 
             if (markerHelper.hasMarkers(editingDomain.getResourceSet())) {
-                markerHelper.deleteMarkers(editingDomain.getResourceSet());
-                if (diagnostic.getSeverity() != Diagnostic.OK) {
-                    try {
-                        markerHelper.createMarkers(diagnostic);
-                    }
-                    catch (CoreException exception) {
-                        VocabularyEditorPlugin.INSTANCE.log(exception);
-                    }
+                try {
+                    markerHelper.updateMarkers(diagnostic);
+                }
+                catch (CoreException exception) {
+                    VocabularyEditorPlugin.INSTANCE.log(exception);
                 }
             }
         }
@@ -1039,6 +1036,7 @@ public class VocabularyEditor
 
                 selectionViewer = (TreeViewer)viewerPane.getViewer();
                 selectionViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
+                selectionViewer.setUseHashlookup(true);
 
                 selectionViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
                 selectionViewer.setInput(editingDomain.getResourceSet());
@@ -1344,6 +1342,7 @@ public class VocabularyEditor
 
                     // Set up the tree viewer.
                     //
+                    contentOutlineViewer.setUseHashlookup(true);
                     contentOutlineViewer.setContentProvider(new AdapterFactoryContentProvider(adapterFactory));
                     contentOutlineViewer.setLabelProvider(new AdapterFactoryLabelProvider(adapterFactory));
                     contentOutlineViewer.setInput(editingDomain.getResourceSet());
@@ -1491,7 +1490,9 @@ public class VocabularyEditor
                     // Save the resources to the file system.
                     //
                     boolean first = true;
-                    for (Resource resource : editingDomain.getResourceSet().getResources()) {
+                    List<Resource> resources = editingDomain.getResourceSet().getResources();
+                    for (int i = 0; i < resources.size(); ++i) {
+                        Resource resource = resources.get(i);
                         if ((first || !resource.getContents().isEmpty() || isPersisted(resource)) && !editingDomain.isReadOnly(resource)) {
                             try {
                                 long timeStamp = resource.getTimeStamp();

--- a/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/Vocabularies.java
+++ b/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/Vocabularies.java
@@ -34,7 +34,7 @@ public interface Vocabularies extends EObject {
      * <!-- end-user-doc -->
      * @return the value of the '<em>Vocabularies</em>' containment reference list.
      * @see vocabulary.VocabularyPackage#getVocabularies_Vocabularies()
-     * @model containment="true"
+     * @model containment="true" keys="label"
      * @generated
      */
     EList<Vocabulary> getVocabularies();

--- a/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/Vocabulary.java
+++ b/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/Vocabulary.java
@@ -170,7 +170,7 @@ public interface Vocabulary extends EObject {
      * <!-- end-user-doc -->
      * @return the value of the '<em>Classes</em>' containment reference list.
      * @see vocabulary.VocabularyPackage#getVocabulary_Classes()
-     * @model containment="true"
+     * @model containment="true" keys="name"
      * @generated
      */
     EList<vocabulary.Class> getClasses();
@@ -186,7 +186,7 @@ public interface Vocabulary extends EObject {
      * <!-- end-user-doc -->
      * @return the value of the '<em>Properties</em>' containment reference list.
      * @see vocabulary.VocabularyPackage#getVocabulary_Properties()
-     * @model containment="true"
+     * @model containment="true" keys="name"
      * @generated
      */
     EList<Property> getProperties();

--- a/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/impl/VocabularyPackageImpl.java
+++ b/org.eclipse.lyo.tools.vocabulary.model/src/vocabulary/impl/VocabularyPackageImpl.java
@@ -407,6 +407,7 @@ public class VocabularyPackageImpl extends EPackageImpl implements VocabularyPac
         // Initialize classes, features, and operations; add parameters
         initEClass(vocabulariesEClass, Vocabularies.class, "Vocabularies", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEReference(getVocabularies_Vocabularies(), this.getVocabulary(), null, "vocabularies", null, 0, -1, Vocabularies.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getVocabularies_Vocabularies().getEKeys().add(this.getVocabulary_Label());
 
         initEClass(vocabularyEClass, Vocabulary.class, "Vocabulary", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEAttribute(getVocabulary_NamespaceURI(), ecorePackage.getEString(), "namespaceURI", null, 1, 1, Vocabulary.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -415,7 +416,9 @@ public class VocabularyPackageImpl extends EPackageImpl implements VocabularyPac
         initEAttribute(getVocabulary_Source(), ecorePackage.getEString(), "source", null, 1, 1, Vocabulary.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getVocabulary_PreferredNamespacePrefix(), ecorePackage.getEString(), "preferredNamespacePrefix", null, 1, 1, Vocabulary.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getVocabulary_Classes(), this.getClass_(), null, "classes", null, 0, -1, Vocabulary.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getVocabulary_Classes().getEKeys().add(this.getTerm_Name());
         initEReference(getVocabulary_Properties(), this.getProperty(), null, "properties", null, 0, -1, Vocabulary.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        getVocabulary_Properties().getEKeys().add(this.getTerm_Name());
 
         initEClass(termEClass, Term.class, "Term", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEAttribute(getTerm_Name(), ecorePackage.getEString(), "name", null, 1, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);


### PR DESCRIPTION
Specify keys for EAttributes within their containing EClass, if they form a set.

This allows for more robust ids when such EAttributes are references
from other parts of hte model (Specifically when references are across
different EMF model files).

For example on how the model will look like, see the file changes on the pull-request on lyo-adaptor-sample-modelling https://github.com/OSLC/lyo-adaptor-sample-modelling/pull/28/files
