### PR TITLE
Remove the Deprecated toHTML() methods from the resource classes.

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
@@ -40,37 +40,6 @@
 "<input name=\"[javaName(aProperty, false)/]\" type=\"text\" style=\"width: 400px\" id=\"[javaName(aProperty, false)/]\" [if (Sequence{'excatlyOne', 'oneOrMany'}->includes(aProperty.occurs.toString()))]required[/if]>"
 [/template]
 
-[template public propertyToHtmlForCreationMethod(aProperty: ResourceProperty, aResource: Resource, aCreationDialog: Dialog, methodSignature: String)]
-@Deprecated
-static public String [propertyToHtmlForCreationMethodName(aProperty, aResource, aCreationDialog)/] (final HttpServletRequest httpServletRequest[commaSeparate(methodSignature, true, false)/])
-{
-    String s = "";
-
-    // [protected ('"Init:'.concat(propertyToHtmlForCreationMethodName(aProperty, aResource, aCreationDialog)).concat('(...'.concat(methodSignature).concat(')"')))]
-    // [/protected]
-
-    s = s + "<label for=\"[aProperty.name/]\">[aProperty.name/]: </LABEL>";
-
-    // [protected ('"Mid:'.concat(propertyToHtmlForCreationMethodName(aProperty, aResource, aCreationDialog)).concat('(...'.concat(methodSignature).concat(')"')))]
-    // [/protected]
-
-    [let valueType : String = aProperty.valueType.toString()]
-    [if (Sequence{'String', 'XMLLiteral', 'DateTime', 'URI', 'Double', 'Float', 'Integer'}->includes(valueType))]
-    s= s + [resourcePropertyAsTextInputForCreation(aProperty) /];
-    [elseif(valueType = 'Boolean')]
-    s= s + "<input name=\"[javaName(aProperty, false)/]\" type=\"radio\" value=\"true\">True<input name=\"[javaName(aProperty, false)/]\" type=\"radio\" value=\"false\">False";
-    [elseif(Sequence{'Resource', 'LocalResource'}->includes(valueType))]
-    [comment TODO: How to deal with properties that are resources? Should then also be created, or should hte user get a list of existing such resources to choose from.
-    Latter sounds most reasonable. For now just ignore such properties./]
-    [/if]
-    [/let]
-    // [protected ('"Finalize:'.concat(propertyToHtmlForCreationMethodName(aProperty, aResource, aCreationDialog)).concat('(...'.concat(methodSignature).concat(')"')))]
-    // [/protected]
-
-    return s;
-}
-[/template]
-
 [template public generateClassHeader(aResource : Resource, contextAdaptorInterface : AdaptorInterface)]
 // [protected ('Copyright')]
 /*******************************************************************************
@@ -119,10 +88,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
@@ -220,58 +185,6 @@ public [javaClassName(aResource) /](final URI about)
     // [/protected]
 }
 
-[for (aBasicCapability: BasicCapability | basicCapabilities(contextAdaptorInterface, aResource))]
-[let methodSuffix: String = (if (basicCapabilities(contextAdaptorInterface, aResource)->size() = 1) then '' else basicCapabilities(contextAdaptorInterface, aResource)->indexOf(aBasicCapability).toString() endif)]
-[if (basicCapabilities(contextAdaptorInterface, aResource)->indexOf(aBasicCapability) = 1)]
-/**
-* @deprecated Use the methods in class {@link [javaClassFullNameForResourcesFactory(contextAdaptorInterface)/]} instead.
-*/
-@Deprecated
-public [javaClassName(aResource)/]([commaSeparate(aResource.instanceMethodSignature(aBasicCapability, false), false, false)/])
-       throws URISyntaxException
-{
-    this (constructURI[methodSuffix/]([commaSeparate(aResource.instanceMethodParameterList(aBasicCapability), false, false)/]));
-    // [protected ('constructor3')]
-    // [/protected]
-}
-[/if]
-
-/**
-* @deprecated Use the methods in class {@link [javaClassFullNameForResourcesFactory(contextAdaptorInterface)/]} instead.
-*/
-@Deprecated
-public static URI constructURI[methodSuffix/]([commaSeparate(aResource.instanceMethodSignature(aBasicCapability, false), false, false)/])
-{
-    String basePath = OSLC4JUtils.getServletURI();
-    Map<String, Object> pathParameters = new HashMap<String, Object>();
-    [for (instanceCompositeID: String | aResource.instanceCompositeID(aBasicCapability))]
-    pathParameters.put("[instanceCompositeID /]", [instanceCompositeID /]);
-    [/for]
-    String instanceURI = "[aResource.instanceURI(aBasicCapability) /]";
-
-    final UriBuilder builder = UriBuilder.fromUri(basePath);
-    return builder.path(instanceURI).buildFromMap(pathParameters);
-}
-
-/**
-* @deprecated Use the methods in class {@link [javaClassFullNameForResourcesFactory(contextAdaptorInterface)/]} instead.
-*/
-@Deprecated
-public static Link constructLink[methodSuffix/]([commaSeparate(aResource.instanceMethodSignature(aBasicCapability, false), false, true)/] final String label)
-{
-    return new Link(constructURI[methodSuffix/]([commaSeparate(aResource.instanceMethodParameterList(aBasicCapability), false, false)/]), label);
-}
-
-/**
-* @deprecated Use the methods in class {@link [javaClassFullNameForResourcesFactory(contextAdaptorInterface)/]} instead.
-*/
-@Deprecated
-public static Link constructLink[methodSuffix/]([commaSeparate(aResource.instanceMethodSignature(aBasicCapability, false), false, false)/])
-{
-    return new Link(constructURI[methodSuffix/]([commaSeparate(aResource.instanceMethodParameterList(aBasicCapability), false, false)/]));
-}
-[/let]
-[/for]
 [/template]
 
 [template public generateResourceShapeMethods(aResource : Resource, contextAdaptorInterface : AdaptorInterface)]
@@ -308,34 +221,6 @@ public String toString(boolean asLocalResource)
     }
 
     // [protected ('toString_finalize')]
-    // [/protected]
-
-    return result;
-}
-
-@Deprecated
-public String toHtml()
-{
-    return toHtml(false);
-}
-
-@Deprecated
-public String toHtml(boolean asLocalResource)
-{
-    String result = "";
-    // [protected ('toHtml_init')]
-    // [/protected]
-
-    if (asLocalResource) {
-        result = toString(true);
-        // [protected ('toHtml_bodyForLocalResource')]
-        // [/protected]
-    }
-    else {
-        result = "<a href=\"" + getAbout() + "\" class=\"oslc-resource-link\">" + toString() + "</a>";
-    }
-
-    // [protected ('toHtml_finalize')]
     // [/protected]
 
     return result;
@@ -427,119 +312,6 @@ public void [javaAttributeSetterMethodName(aProperty, aResource)/](final [javaAt
 [/for]
 [/template]
 
-[template public generateAttributeToHtmlMethods(aResource : Resource, contextAdaptorInterface : AdaptorInterface)]
-[for (aProperty: ResourceProperty | ((aResource.resourceProperties->asSequence())->union(interfaceProperties(aResource))))]
-[propertyToHtmlForCreationMethod(aProperty, aResource, null, '')/]
-
-[for (aCreationDialog: Dialog| contextAdaptorInterface.creationDialogs(aResource))]
-[propertyToHtmlForCreationMethod(aProperty, aResource, aCreationDialog, dialogMethodSignature(aCreationDialog, false, false))/]
-[/for]
-[/for]
-
-[comment TODO: This ToHTML is quite complicated. At the moment, I get expections because some of the properties are null.
-I am getting to many if/else-ses. I think I need to rethink calmely to have a cleaner structure. Good enough for now I hope. /]
-[for (aProperty: ResourceProperty | ((aResource.resourceProperties->asSequence())->union(interfaceProperties(aResource))))]
-@Deprecated
-public String [javaAttributeName(aProperty, aResource) /]ToHtml()
-{
-    String s = "";
-
-    // [protected (javaAttributeName(aProperty, aResource).concat('toHtml_mid'))]
-    // [/protected]
-
-    try {
-    [comment For these basic valueTypes, one can simply call toString on the attribte /]
-    [if (Sequence{'Boolean', 'String', 'XMLLiteral', 'DateTime', 'URI', 'Double', 'Float', 'Integer'}->includes(aProperty.valueType.toString()))]
-        [if (Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString()))]
-        s = s + "<ul>";
-        Iterator<[javaAttributeBaseType(aProperty) /]> itr = [javaAttributeName(aProperty, aResource) /].iterator();
-        while(itr.hasNext()) {
-            s = s + "<li>";
-            s= s + itr.next().toString();
-            s = s + "</li>";
-        }
-        s = s + "</ul>";
-        [else]
-        if ([javaAttributeName(aProperty, aResource)/] == null) {
-            s = s + "<em>null</em>";
-        }
-        else {
-            s = s + [javaAttributeName(aProperty, aResource)/].toString();
-        }
-        [/if]
-    [comment a property with valueType of resource or LocalResource can return either a Class directly referring to a Resource, or Link.
-    If we get a Link, we want to check if we can also work out which kind of resource class this Link refers to. If we can find out,
-    we want to call toHtml on that class. if we cannot, we simply print the Link as a string. /]
-    [elseif(Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString()))]
-        [if (Sequence{'zeroOrMany', 'oneOrMany'}->includes(aProperty.occurs.toString()))]
-        s = s + "<ul>";
-        for([javaAttributeBaseType(aProperty) /] next : [javaAttributeName(aProperty, aResource) /]) {
-            s = s + "<li>";
-            [if (javaAttributeBaseType(aProperty) = 'Link')]
-                [if (aProperty.range->size() = 1)]
-                    [comment Even if it is a Link, there are cases where I actually know that the link should point to a particular resource class.
-                    (For example, for valueType = Resource, we get a Link irrespective of whether the valueType is set to a specific resource or not. ) /]
-            s = s + (new [javaClassName(aProperty.range->first()) /] (next.getValue())).toHtml([if (aProperty.valueType.toString() = 'LocalResource')]true[else]false[/if]);
-                [else]
-                    [comment just print the Link's URI as a String /]
-            if (next.getValue() == null) {
-                s= s + "<em>null</em>";
-            }
-            else {
-                s = s + "<a href=\"" + next.getValue().toString() + "\">" + next.getValue().toString() + "</a>";
-            }
-                [/if]
-            [else]
-                [comment itr refers to direct Resource class, and hence can simply call toHtml() on /]
-            s = s + next.toHtml([if (aProperty.valueType.toString() = 'LocalResource')]true[else]false[/if]);
-            [/if]
-            s = s + "</li>";
-        }
-        s = s + "</ul>";
-        [else]
-            [if (javaAttributeBaseType(aProperty) = 'Link')]
-                [if (aProperty.range->size() = 1)]
-                    [comment Even if it is a Link, there are cases where I actually know that the link should point to a particular resource class.
-                    (For example, for valueType = Resource, we get a Link irrespective of whether the valueType is set to a specific resource or not. ) /]
-        if (([javaAttributeName(aProperty, aResource)/] == null) || ([javaAttributeName(aProperty, aResource)/].getValue() == null)) {
-            s = s + "<em>null</em>";
-        }
-        else {
-            s = s + (new [javaClassName(aProperty.range->first()) /] ([javaAttributeName(aProperty, aResource)/].getValue())).toHtml([if (aProperty.valueType.toString() = 'LocalResource')]true[else]false[/if]);
-        }
-                [else]
-                    [comment just print the Link's URI as a String /]
-        if (([javaAttributeName(aProperty, aResource)/] == null) || ([javaAttributeName(aProperty, aResource)/].getValue() == null)) {
-            s = s + "<em>null</em>";
-        }
-        else {
-            s = s + [javaAttributeName(aProperty, aResource)/].getValue().toString();
-        }
-                [/if]
-            [else]
-                [comment the attribute refers to direct Resource class, and hence can simply call toHtml() on /]
-        if ([javaAttributeName(aProperty, aResource)/] == null) {
-            s = s + "<em>null</em>";
-        }
-        else {
-            s = s + [javaAttributeName(aProperty, aResource)/].toHtml([if (aProperty.valueType.toString() = 'LocalResource')]true[else]false[/if]);
-        }
-            [/if]
-        [/if]
-    [/if]
-    } catch (Exception e) {
-        e.printStackTrace();
-    }
-
-    // [protected (javaAttributeName(aProperty, aResource).concat('toHtml_finalize'))]
-    // [/protected]
-
-    return s;
-}
-
-[/for]
-[/template]
-
 [template public generateResource(aResource : Resource, contextAdaptorInterface : AdaptorInterface, defaultJavaFilesPath : String, defaultJavaClassPackageName : String)]
 [file (javaClassFullFileName(aResource, contextAdaptorInterface, defaultJavaFilesPath, defaultJavaClassPackageName), false, 'UTF-8')]
 [generateClassHeader(aResource, contextAdaptorInterface)/]
@@ -562,7 +334,6 @@ public String [javaAttributeName(aProperty, aResource) /]ToHtml()
     [generateAddToAttributeMethods(aResource, contextAdaptorInterface)/]
     [generateGetters(aResource, contextAdaptorInterface)/]
     [generateSetters(aResource, contextAdaptorInterface)/]
-    [generateAttributeToHtmlMethods(aResource, contextAdaptorInterface)/]
 }
 [/file]
 [/template]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
@@ -74,10 +74,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;


### PR DESCRIPTION
Remove the Deprecated toHTML() methods from the resource classes.

To view samples of (1) the resource classes (2) the update jsp pages, see the sample-adaptors on
https://github.com/OSLC/lyo-adaptor-sample-modelling/pull/29

**Note** that jsp pages will NOT be regenerated unless they are first removed. This is because we encapsluate the entire jsp code within "protected user code" section.
So, any unremoved jsp pages that still rely on toHtml() methods will fail.
