### PR TITLE
Refactoring ServiceProvider code from the SPC Singleton to the SP-Factory

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
@@ -67,8 +67,11 @@ package [javaClassPackageNameForFactory(aServiceProvider) /];
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Map;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
@@ -98,15 +101,45 @@ public class [javaClassNameForFactory(aServiceProvider) /]
         super();
     }
 
+    public static URI constructURI([aServiceProvider.instanceMethodSignature() /])
+    {
+        String basePath = OSLC4JUtils.getServletURI();
+        Map<String, Object> pathParameters = new HashMap<String, Object>();
+        [for (instanceCompositeID: String | aServiceProvider.instanceCompositeID()) separator(lineSeparator())]
+        pathParameters.put("[instanceCompositeID /]", [instanceCompositeID /]);
+        [/for]
+        String instanceURI = "[aServiceProvider.instanceURI() /]";
+
+        final UriBuilder builder = UriBuilder.fromUri(basePath);
+        return builder.path(instanceURI).buildFromMap(pathParameters);
+    }
+
+    public static URI constructURI(final [javaClassName(aServiceProvider) /] serviceProviderInfo)
+    {
+        return constructURI([for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for]);
+    }
+
+    public static String constructIdentifier([aServiceProvider.instanceMethodSignature() /])
+    {
+        return [for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(' + "/" + ')][instanceCompositeID/][/for];
+    }
+
+    public static String constructIdentifier(final [javaClassName(aServiceProvider) /] serviceProviderInfo)
+    {
+        return constructIdentifier([for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for]);
+    }
+
     public static ServiceProvider createServiceProvider(final [javaClassName(aServiceProvider) /] serviceProviderInfo) 
             throws OslcCoreApplicationException, URISyntaxException, IllegalArgumentException {
         // [protected ('init')]
         // [/protected]
+        URI serviceProviderURI = constructURI(serviceProviderInfo);
+        String identifier = constructIdentifier(serviceProviderInfo);
         String basePath = OSLC4JUtils.getServletURI();
         String title = String.format("Service Provider '%s'", serviceProviderInfo.name);
         String description = String.format("%s (id: %s; kind: %s)",
             "[aServiceProvider.description /]",
-            [for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(' + "/" + ')]serviceProviderInfo.[instanceCompositeID/][/for],
+            identifier,
             "[aServiceProvider.title /]");
         [if (aServiceProvider.publisher.oclIsUndefined())]
         Publisher publisher = null;
@@ -117,23 +150,14 @@ public class [javaClassNameForFactory(aServiceProvider) /]
         [for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(lineSeparator())]
         parameterMap.put("[instanceCompositeID /]", serviceProviderInfo.[instanceCompositeID /]);
         [/for]
-        // [protected ('finalize')]
-        // [/protected]
-        return createServiceProvider(basePath, title, description, publisher, parameterMap);
-    }
 
-    public static ServiceProvider createServiceProvider(final String baseURI, final String title, final String description, final Publisher publisher, final Map<String,Object> parameterValueMap)
-           throws OslcCoreApplicationException, URISyntaxException
-    {
-        final ServiceProvider serviceProvider = ServiceProviderFactory.createServiceProvider(baseURI,
+        ServiceProvider serviceProvider = ServiceProviderFactory.createServiceProvider(basePath,
                                                     "",
                                                     title,
                                                     description,
                                                     publisher,
                                                     RESOURCE_CLASSES,
-                                                    parameterValueMap);
-        URI detailsURIs[ '[' ']' /] = {new URI(baseURI)};
-        serviceProvider.setDetails(detailsURIs);
+                                                    parameterMap);
 
         final PrefixDefinition[ '[' ']' /] prefixDefinitions =
         {
@@ -146,9 +170,15 @@ public class [javaClassNameForFactory(aServiceProvider) /]
             new PrefixDefinition([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespacePrefixConstantName(aDomainSpecification) /], new URI([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespaceConstantName(aDomainSpecification) /]))
             [/for]
         };
-
         serviceProvider.setPrefixDefinitions(prefixDefinitions);
 
+        serviceProvider.setAbout(serviceProviderURI);
+        serviceProvider.setIdentifier(identifier);
+        serviceProvider.setCreated(new Date());
+        serviceProvider.setDetails(new URI[ '[' ']' /] {serviceProviderURI});
+
+        // [protected ('finalize')]
+        // [/protected]
         return serviceProvider;
     }
 }

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
@@ -136,7 +136,7 @@ public class [javaClassNameForFactory(aServiceProvider) /]
         URI serviceProviderURI = constructURI(serviceProviderInfo);
         String identifier = constructIdentifier(serviceProviderInfo);
         String basePath = OSLC4JUtils.getServletURI();
-        String title = String.format("Service Provider '%s'", serviceProviderInfo.name);
+        String title = serviceProviderInfo.name;
         String description = String.format("%s (id: %s; kind: %s)",
             "[aServiceProvider.description /]",
             identifier,

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
@@ -65,9 +65,6 @@ package [javaClassPackageNameForSingleton(aServiceProviderCatalog) /];
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
@@ -79,7 +76,6 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
-import org.eclipse.lyo.oslc4j.core.model.Publisher;
 import org.eclipse.lyo.oslc4j.core.model.Service;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProviderCatalog;
@@ -165,37 +161,17 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
     }
 
     [for (aServiceProvider: ServiceProvider | aServiceProviderCatalog.serviceProviders)]
-
-    private static URI construct[aServiceProvider.javaName(true)/]URI([aServiceProvider.instanceMethodSignature() /])
-    {
-        String basePath = OSLC4JUtils.getServletURI();
-        Map<String, Object> pathParameters = new HashMap<String, Object>();
-        [for (instanceCompositeID: String | aServiceProvider.instanceCompositeID()) separator(lineSeparator())]
-        pathParameters.put("[instanceCompositeID /]", [instanceCompositeID /]);
-        [/for]
-        String instanceURI = "[aServiceProvider.instanceURI() /]";
-
-        final UriBuilder builder = UriBuilder.fromUri(basePath);
-        return builder.path(instanceURI).buildFromMap(pathParameters);
+    public static boolean contains[aServiceProvider.javaName(true)/](final [javaClassName(aServiceProvider) /] serviceProviderInfo) {
+        return serviceProviders.containsKey([javaClassNameForFactory(aServiceProvider)/].constructIdentifier(serviceProviderInfo));
     }
 
-    private static String [aServiceProvider.javaName(false)/]Identifier([aServiceProvider.instanceMethodSignature() /])
-    {
-        String identifier = [for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(' + "/" + ')][instanceCompositeID/][/for];
-        return identifier;
-    }
-
-    public static boolean contains[aServiceProvider.javaName(true)/]([aServiceProvider.instanceMethodSignature() /]) {
-        return serviceProviders.containsKey([aServiceProvider.javaName(false)/]Identifier([aServiceProvider.instanceMethodParameterList()/]));
-    }
-
-    public static ServiceProvider get[aServiceProvider.javaName(true)/](HttpServletRequest httpServletRequest, [aServiceProvider.instanceMethodSignature() /])
+    public static ServiceProvider get[aServiceProvider.javaName(true)/](HttpServletRequest httpServletRequest, [aServiceProvider.instanceMethodSignature()/])
     {
         ServiceProvider serviceProvider;
 
         synchronized(serviceProviders)
         {
-            String identifier = [aServiceProvider.javaName(false)/]Identifier([aServiceProvider.instanceMethodParameterList() /]);
+            String identifier = [javaClassNameForFactory(aServiceProvider)/].constructIdentifier([aServiceProvider.instanceMethodParameterList()/]);
             serviceProvider = serviceProviders.get(identifier);
 
             //One retry refreshing the service providers
@@ -216,24 +192,20 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
 
     public static ServiceProvider create[aServiceProvider.javaName(true)/](final [javaClassName(aServiceProvider) /] serviceProviderInfo) 
             throws OslcCoreApplicationException, URISyntaxException, IllegalArgumentException {
-        String identifier = [aServiceProvider.javaName(false)/]Identifier([for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for]);
-        if (contains[aServiceProvider.javaName(true)/]([for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for])) {
+        String identifier = [javaClassNameForFactory(aServiceProvider)/].constructIdentifier(serviceProviderInfo);
+        if (contains[aServiceProvider.javaName(true)/](serviceProviderInfo)) {
             throw new IllegalArgumentException(String.format("The SP '%s' was already registered", identifier));
         }
         return [javaClassNameForFactory(aServiceProvider)/].createServiceProvider(serviceProviderInfo);
     }
 
     public static ServiceProvider register[aServiceProvider.javaName(true)/](final HttpServletRequest httpServletRequest,
-                                                          final ServiceProvider serviceProvider,
-                                                          [aServiceProvider.instanceMethodSignature() /])
+                                                          final ServiceProvider serviceProvider)
                                                 throws URISyntaxException
     {
         synchronized(serviceProviders)
         {
-            final URI serviceProviderURI = construct[aServiceProvider.javaName(true)/]URI([aServiceProvider.instanceMethodParameterList() /]);
-            return register[aServiceProvider.javaName(true)/]NoSync(serviceProviderURI,
-                                                 serviceProvider,
-                                                 [aServiceProvider.instanceMethodParameterList() /]);
+            return register[aServiceProvider.javaName(true)/]NoSync(serviceProvider);
         }
     }
 
@@ -241,35 +213,22 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
     * Register a service provider with the OSLC catalog
     *
     */
-    private static ServiceProvider register[aServiceProvider.javaName(true)/]NoSync(final URI serviceProviderURI,
-                                                                 final ServiceProvider serviceProvider
-                                                                 [commaSeparate(aServiceProvider.instanceMethodSignature(), true, false)/])
+    private static ServiceProvider register[aServiceProvider.javaName(true)/]NoSync(final ServiceProvider serviceProvider)
     {
         final SortedSet<URI> serviceProviderDomains = getServiceProviderDomains(serviceProvider);
-
-        String identifier = [aServiceProvider.javaName(false)/]Identifier([aServiceProvider.instanceMethodParameterList()/]);
-        serviceProvider.setAbout(serviceProviderURI);
-        serviceProvider.setIdentifier(identifier);
-        serviceProvider.setCreated(new Date());
-        serviceProvider.setDetails(new URI[ '[' ']' /] {serviceProviderURI});
-
         serviceProviderCatalog.addServiceProvider(serviceProvider);
         serviceProviderCatalog.addDomains(serviceProviderDomains);
-
-        serviceProviders.put(identifier, serviceProvider);
-
+        serviceProviders.put(serviceProvider.getIdentifier(), serviceProvider);
         return serviceProvider;
     }
 
     // This version is for self-registration and thus package-protected
-    static ServiceProvider register[aServiceProvider.javaName(true)/](final ServiceProvider serviceProvider[commaSeparate(aServiceProvider.instanceMethodSignature(), true, false)/])
+    static ServiceProvider register[aServiceProvider.javaName(true)/](final ServiceProvider serviceProvider)
                                             throws URISyntaxException
     {
         synchronized(serviceProviders)
         {
-            final URI serviceProviderURI = construct[aServiceProvider.javaName(true)/]URI([aServiceProvider.instanceMethodParameterList()/]);
-
-            return register[aServiceProvider.javaName(true)/]NoSync(serviceProviderURI, serviceProvider[commaSeparate(aServiceProvider.instanceMethodParameterList(), true, false)/]);
+            return register[aServiceProvider.javaName(true)/]NoSync(serviceProvider);
         }
     }
 
@@ -278,7 +237,7 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         synchronized(serviceProviders)
         {
             final ServiceProvider deregisteredServiceProvider =
-                serviceProviders.remove([aServiceProvider.javaName(false)/]Identifier([aServiceProvider.instanceMethodParameterList()/]));
+                serviceProviders.remove([javaClassNameForFactory(aServiceProvider)/].constructIdentifier([aServiceProvider.instanceMethodParameterList()/]));
 
             if (deregisteredServiceProvider != null)
             {
@@ -336,9 +295,9 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
             [javaClassName(aServiceProvider) /] [ '[' ']' /] [javaClassName(aServiceProvider).toLowerFirst()/]s = [javaClassNameForAdaptorManager(containingAdaptorInterface(aServiceProviderCatalog)) /].get[aServiceProvider.javaClassName()/]s(httpServletRequest);
             //Register each service provider
             for ([javaClassName(aServiceProvider) /] serviceProviderInfo : [javaClassName(aServiceProvider).toLowerFirst()/]s) {
-                if (!contains[aServiceProvider.javaName(true)/]([for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for])) {
+                if (!contains[aServiceProvider.javaName(true)/](serviceProviderInfo)) {
                     ServiceProvider aServiceProvider = create[aServiceProvider.javaName(true)/](serviceProviderInfo);
-                    register[aServiceProvider.javaName(true)/](aServiceProvider, [for (instanceCompositeID: String | instanceCompositeID(aServiceProvider)) separator(', ')]serviceProviderInfo.[instanceCompositeID /][/for]);
+                    register[aServiceProvider.javaName(true)/](aServiceProvider);
                 }
             }
             [/for]
@@ -348,15 +307,6 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         }
     }
 }
-
 [/file]
 [/template]
-
-
-
-
-
-
-
-
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
@@ -168,15 +168,8 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         return containsServiceProvider(serviceProvider.getIdentifier());
     }
 
-    public static ServiceProvider register(final HttpServletRequest httpServletRequest,
-                                                          final ServiceProvider serviceProvider)
-                                                throws URISyntaxException
-    {
-        return register(serviceProvider);
-    }
-
     // This version is for self-registration and thus package-protected
-    static ServiceProvider register(final ServiceProvider serviceProvider)
+    public static ServiceProvider register(final ServiceProvider serviceProvider)
                                             throws URISyntaxException
     {
         if (containsServiceProvider(serviceProvider)) {
@@ -184,6 +177,9 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         }
         synchronized(serviceProviders)
         {
+            if (containsServiceProvider(serviceProvider)) {
+                throw new IllegalArgumentException(String.format("The SP '%s' was already registered", serviceProvider.getIdentifier()));
+            }
             return registerNoSync(serviceProvider);
         }
     }
@@ -200,6 +196,36 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         serviceProviders.put(serviceProvider.getIdentifier(), serviceProvider);
         return serviceProvider;
     }
+
+    public static void deregister(final ServiceProvider serviceProvider)
+    {
+        synchronized(serviceProviders)
+        {
+            final ServiceProvider deregisteredServiceProvider =
+                serviceProviders.remove(serviceProvider.getIdentifier());
+
+            if (deregisteredServiceProvider != null)
+            {
+                final SortedSet<URI> remainingDomains = new TreeSet<URI>();
+
+                for (final ServiceProvider remainingServiceProvider : serviceProviders.values())
+                {
+                    remainingDomains.addAll(getServiceProviderDomains(remainingServiceProvider));
+                }
+
+                final SortedSet<URI> removedServiceProviderDomains = getServiceProviderDomains(deregisteredServiceProvider);
+
+                removedServiceProviderDomains.removeAll(remainingDomains);
+                serviceProviderCatalog.removeDomains(removedServiceProviderDomains);
+                serviceProviderCatalog.removeServiceProvider(deregisteredServiceProvider);
+            }
+            else
+            {
+                throw new WebApplicationException(Status.NOT_FOUND);
+            }
+        }
+    }
+
 
     [for (aServiceProvider: ServiceProvider | aServiceProviderCatalog.serviceProviders)]
     public static ServiceProvider get[aServiceProvider.javaName(true)/](HttpServletRequest httpServletRequest, [aServiceProvider.instanceMethodSignature()/])
@@ -225,35 +251,6 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
-    }
-
-    public static void deregister[aServiceProvider.javaName(true)/]([aServiceProvider.instanceMethodSignature()/])
-    {
-        synchronized(serviceProviders)
-        {
-            final ServiceProvider deregisteredServiceProvider =
-                serviceProviders.remove([javaClassNameForFactory(aServiceProvider)/].constructIdentifier([aServiceProvider.instanceMethodParameterList()/]));
-
-            if (deregisteredServiceProvider != null)
-            {
-                final SortedSet<URI> remainingDomains = new TreeSet<URI>();
-
-                for (final ServiceProvider remainingServiceProvider : serviceProviders.values())
-                {
-                    remainingDomains.addAll(getServiceProviderDomains(remainingServiceProvider));
-                }
-
-                final SortedSet<URI> removedServiceProviderDomains = getServiceProviderDomains(deregisteredServiceProvider);
-
-                removedServiceProviderDomains.removeAll(remainingDomains);
-                serviceProviderCatalog.removeDomains(removedServiceProviderDomains);
-                serviceProviderCatalog.removeServiceProvider(deregisteredServiceProvider);
-            }
-            else
-            {
-                throw new WebApplicationException(Status.NOT_FOUND);
-            }
-        }
     }
     [/for]
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogSingleton.mtl
@@ -160,11 +160,48 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         }
     }
 
-    [for (aServiceProvider: ServiceProvider | aServiceProviderCatalog.serviceProviders)]
-    public static boolean contains[aServiceProvider.javaName(true)/](final [javaClassName(aServiceProvider) /] serviceProviderInfo) {
-        return serviceProviders.containsKey([javaClassNameForFactory(aServiceProvider)/].constructIdentifier(serviceProviderInfo));
+    public static boolean containsServiceProvider(final String identifier) {
+        return serviceProviders.containsKey(identifier);
     }
 
+    public static boolean containsServiceProvider(final ServiceProvider serviceProvider) {
+        return containsServiceProvider(serviceProvider.getIdentifier());
+    }
+
+    public static ServiceProvider register(final HttpServletRequest httpServletRequest,
+                                                          final ServiceProvider serviceProvider)
+                                                throws URISyntaxException
+    {
+        return register(serviceProvider);
+    }
+
+    // This version is for self-registration and thus package-protected
+    static ServiceProvider register(final ServiceProvider serviceProvider)
+                                            throws URISyntaxException
+    {
+        if (containsServiceProvider(serviceProvider)) {
+            throw new IllegalArgumentException(String.format("The SP '%s' was already registered", serviceProvider.getIdentifier()));
+        }
+        synchronized(serviceProviders)
+        {
+            return registerNoSync(serviceProvider);
+        }
+    }
+
+    /**
+    * Register a service provider with the OSLC catalog
+    *
+    */
+    private static ServiceProvider registerNoSync(final ServiceProvider serviceProvider)
+    {
+        final SortedSet<URI> serviceProviderDomains = getServiceProviderDomains(serviceProvider);
+        serviceProviderCatalog.addServiceProvider(serviceProvider);
+        serviceProviderCatalog.addDomains(serviceProviderDomains);
+        serviceProviders.put(serviceProvider.getIdentifier(), serviceProvider);
+        return serviceProvider;
+    }
+
+    [for (aServiceProvider: ServiceProvider | aServiceProviderCatalog.serviceProviders)]
     public static ServiceProvider get[aServiceProvider.javaName(true)/](HttpServletRequest httpServletRequest, [aServiceProvider.instanceMethodSignature()/])
     {
         ServiceProvider serviceProvider;
@@ -188,48 +225,6 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
-    }
-
-    public static ServiceProvider create[aServiceProvider.javaName(true)/](final [javaClassName(aServiceProvider) /] serviceProviderInfo) 
-            throws OslcCoreApplicationException, URISyntaxException, IllegalArgumentException {
-        String identifier = [javaClassNameForFactory(aServiceProvider)/].constructIdentifier(serviceProviderInfo);
-        if (contains[aServiceProvider.javaName(true)/](serviceProviderInfo)) {
-            throw new IllegalArgumentException(String.format("The SP '%s' was already registered", identifier));
-        }
-        return [javaClassNameForFactory(aServiceProvider)/].createServiceProvider(serviceProviderInfo);
-    }
-
-    public static ServiceProvider register[aServiceProvider.javaName(true)/](final HttpServletRequest httpServletRequest,
-                                                          final ServiceProvider serviceProvider)
-                                                throws URISyntaxException
-    {
-        synchronized(serviceProviders)
-        {
-            return register[aServiceProvider.javaName(true)/]NoSync(serviceProvider);
-        }
-    }
-
-    /**
-    * Register a service provider with the OSLC catalog
-    *
-    */
-    private static ServiceProvider register[aServiceProvider.javaName(true)/]NoSync(final ServiceProvider serviceProvider)
-    {
-        final SortedSet<URI> serviceProviderDomains = getServiceProviderDomains(serviceProvider);
-        serviceProviderCatalog.addServiceProvider(serviceProvider);
-        serviceProviderCatalog.addDomains(serviceProviderDomains);
-        serviceProviders.put(serviceProvider.getIdentifier(), serviceProvider);
-        return serviceProvider;
-    }
-
-    // This version is for self-registration and thus package-protected
-    static ServiceProvider register[aServiceProvider.javaName(true)/](final ServiceProvider serviceProvider)
-                                            throws URISyntaxException
-    {
-        synchronized(serviceProviders)
-        {
-            return register[aServiceProvider.javaName(true)/]NoSync(serviceProvider);
-        }
     }
 
     public static void deregister[aServiceProvider.javaName(true)/]([aServiceProvider.instanceMethodSignature()/])
@@ -295,9 +290,9 @@ public class [javaClassNameForSingleton(aServiceProviderCatalog) /]
             [javaClassName(aServiceProvider) /] [ '[' ']' /] [javaClassName(aServiceProvider).toLowerFirst()/]s = [javaClassNameForAdaptorManager(containingAdaptorInterface(aServiceProviderCatalog)) /].get[aServiceProvider.javaClassName()/]s(httpServletRequest);
             //Register each service provider
             for ([javaClassName(aServiceProvider) /] serviceProviderInfo : [javaClassName(aServiceProvider).toLowerFirst()/]s) {
-                if (!contains[aServiceProvider.javaName(true)/](serviceProviderInfo)) {
-                    ServiceProvider aServiceProvider = create[aServiceProvider.javaName(true)/](serviceProviderInfo);
-                    register[aServiceProvider.javaName(true)/](aServiceProvider);
+                if (!containsServiceProvider([javaClassNameForFactory(aServiceProvider)/].constructIdentifier(serviceProviderInfo))) {
+                    ServiceProvider aServiceProvider = [javaClassNameForFactory(aServiceProvider)/].createServiceProvider(serviceProviderInfo);
+                    register(aServiceProvider);
                 }
             }
             [/for]


### PR DESCRIPTION
Fixes https://github.com/eclipse/lyo.designer/issues/89

Closes https://github.com/eclipse/lyo.designer/pull/90

Resulting java code can be found in branch https://github.com/OSLC/lyo-adaptor-sample-modelling/tree/SPFactoryMore, project rm-adaptor.
Sample contains 2 types of SPs: (1) simple single id (2) composite id id1/{id1}/id2/{id2}
