### PR TITLE
Provide control on whether a certain domainSpecification should be generated or not.

### DIFF
--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -228,6 +228,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="GenerationSetting">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="javaClassPackageName" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="javaFilesPath" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="doNotGenerate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Shape" abstract="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="ShaclShape" eSuperTypes="#//Shape">

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -185,6 +185,7 @@
     <genClasses ecoreClass="adaptorInterface.ecore#//GenerationSetting">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//GenerationSetting/javaClassPackageName"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//GenerationSetting/javaFilesPath"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//GenerationSetting/doNotGenerate"/>
     </genClasses>
     <genClasses image="false" ecoreClass="adaptorInterface.ecore#//Shape"/>
     <genClasses ecoreClass="adaptorInterface.ecore#//ShaclShape">

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
@@ -55,6 +55,7 @@ public static String [resourceTypeConstantName(aResource)/] = [resourceTypeNames
 [/template]
 
 [template public generateDomainSpecificationConstants(aDomainSpecification: DomainSpecification, anAdaptorInterface : AdaptorInterface, defaultJavaFilesPath : String, defaultJavaClassPackageName : String)]
+[if (not aDomainSpecification.doNotGenerate())]
 [file (javaInterfaceFullFileNameForConstants(aDomainSpecification, anAdaptorInterface, defaultJavaFilesPath, defaultJavaClassPackageName), false, 'UTF-8')]
 // [protected ('Copyright')]
 /*******************************************************************************
@@ -103,4 +104,5 @@ public interface [javaInterfaceNameForConstants(aDomainSpecification) /]
     [/for]
 }
 [/file]
+[/if]
 [/template]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResource.mtl
@@ -317,6 +317,7 @@ public void [javaAttributeSetterMethodName(aProperty, aResource)/](final [javaAt
 [/template]
 
 [template public generateResource(aResource : Resource, contextAdaptorInterface : AdaptorInterface, defaultJavaFilesPath : String, defaultJavaClassPackageName : String)]
+[if (aResource.generate())]
 [file (javaClassFullFileName(aResource, contextAdaptorInterface, defaultJavaFilesPath, defaultJavaClassPackageName), false, 'UTF-8')]
 [generateClassHeader(aResource, contextAdaptorInterface)/]
 
@@ -340,4 +341,5 @@ public void [javaAttributeSetterMethodName(aProperty, aResource)/](final [javaAt
     [generateSetters(aResource, contextAdaptorInterface)/]
 }
 [/file]
+[/if]
 [/template]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
@@ -32,6 +32,7 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
 
 [template public generateResourceInterface(aResource : Resource, contextAdaptorInterface : AdaptorInterface, managingAdaptorInterface: AdaptorInterface, defaultJavaFilesPath : String, defaultJavaClassPackageName : String)]
+[if (aResource.generate())]
 [file (javaInterfaceFullFileName(aResource, contextAdaptorInterface, defaultJavaFilesPath, defaultJavaClassPackageName), false, 'UTF-8')]
 // [protected ('Copyright')]
 /*******************************************************************************
@@ -164,4 +165,5 @@ public interface [javaInterfaceName(aResource) /]
 }
 
 [/file]
+[/if]
 [/template]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/domainSpecificationServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/domainSpecificationServices.mtl
@@ -54,6 +54,14 @@ else
 endif)
 /]
 
+[query public doNotGenerate(aSpecification: Specification) : Boolean = 
+(if (aSpecification.generationSetting.oclIsUndefined())._or(aSpecification.generationSetting.doNotGenerate.oclIsUndefined()) then 
+    false
+else
+    aSpecification.generationSetting.doNotGenerate
+endif)
+/]
+
 [query public javaFullFilesPath(aDomainSpecification: DomainSpecification, anAdaptorInterface : AdaptorInterface, default : String) : String = 
 (if (aDomainSpecification.generationSetting.oclIsUndefined())._or(aDomainSpecification.generationSetting.javaFilesPath.isNullOrEmpty()) then 
     javaFullFilesPath(aDomainSpecification.eContainer(Specification), anAdaptorInterface, default)
@@ -67,6 +75,14 @@ endif)
     javaPackageName(aDomainSpecification.eContainer(Specification), anAdaptorInterface, default)
 else
     aDomainSpecification.generationSetting.javaClassPackageName
+endif)
+/]
+
+[query public doNotGenerate(aDomainSpecification: DomainSpecification) : Boolean = 
+(if (aDomainSpecification.generationSetting.oclIsUndefined())._or(aDomainSpecification.generationSetting.doNotGenerate.oclIsUndefined()) then 
+    doNotGenerate(aDomainSpecification.eContainer(Specification))
+else
+    aDomainSpecification.generationSetting.doNotGenerate
 endif)
 /]
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourceServices.mtl
@@ -23,6 +23,10 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
 
+[query public generate(aResource: Resource) : Boolean = 
+    not aResource.definingDomainSpecification().doNotGenerate()
+/]
+
 [query public directParentResource(aResource: Resource) : Resource =
     (if (aResource.extends->notEmpty()) then 
         aResource.extends->first()

--- a/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
@@ -181,3 +181,4 @@ _UI_AdaptorInterface_swaggerSupport_feature = Swagger Support
 _UI_AdaptorInterface_swaggerDocumentation_feature = Swagger Documentation
 _UI_AdaptorInterface_generateJspFiles_feature = Generate Jsp Files
 _UI_AdaptorInterface_doNotRegenerateJspFiles_feature = Do Not Regenerate Jsp Files
+_UI_GenerationSetting_doNotGenerate_feature = Do Not Generate

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/GenerationSettingItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/GenerationSettingItemProvider.java
@@ -62,6 +62,7 @@ public class GenerationSettingItemProvider
 
 			addJavaClassPackageNamePropertyDescriptor(object);
 			addJavaFilesPathPropertyDescriptor(object);
+			addDoNotGeneratePropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -111,6 +112,28 @@ public class GenerationSettingItemProvider
 	}
 
 	/**
+	 * This adds a property descriptor for the Do Not Generate feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addDoNotGeneratePropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_GenerationSetting_doNotGenerate_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_GenerationSetting_doNotGenerate_feature", "_UI_GenerationSetting_type"),
+				 AdaptorinterfacePackage.Literals.GENERATION_SETTING__DO_NOT_GENERATE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
 	 * This returns GenerationSetting.gif.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -150,6 +173,7 @@ public class GenerationSettingItemProvider
 		switch (notification.getFeatureID(GenerationSetting.class)) {
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_CLASS_PACKAGE_NAME:
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_FILES_PATH:
+			case AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 				return;
 		}

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
@@ -1482,13 +1482,22 @@ public interface AdaptorinterfacePackage extends EPackage {
 	int GENERATION_SETTING__JAVA_FILES_PATH = 1;
 
 	/**
+	 * The feature id for the '<em><b>Do Not Generate</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int GENERATION_SETTING__DO_NOT_GENERATE = 2;
+
+	/**
 	 * The number of structural features of the '<em>Generation Setting</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int GENERATION_SETTING_FEATURE_COUNT = 2;
+	int GENERATION_SETTING_FEATURE_COUNT = 3;
 
 	/**
 	 * The number of operations of the '<em>Generation Setting</em>' class.
@@ -2953,6 +2962,17 @@ public interface AdaptorinterfacePackage extends EPackage {
 	EAttribute getGenerationSetting_JavaFilesPath();
 
 	/**
+	 * Returns the meta object for the attribute '{@link adaptorinterface.GenerationSetting#isDoNotGenerate <em>Do Not Generate</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Do Not Generate</em>'.
+	 * @see adaptorinterface.GenerationSetting#isDoNotGenerate()
+	 * @see #getGenerationSetting()
+	 * @generated
+	 */
+	EAttribute getGenerationSetting_DoNotGenerate();
+
+	/**
 	 * Returns the meta object for class '{@link adaptorinterface.Shape <em>Shape</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -4143,6 +4163,14 @@ public interface AdaptorinterfacePackage extends EPackage {
 		 * @generated
 		 */
 		EAttribute GENERATION_SETTING__JAVA_FILES_PATH = eINSTANCE.getGenerationSetting_JavaFilesPath();
+
+		/**
+		 * The meta object literal for the '<em><b>Do Not Generate</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute GENERATION_SETTING__DO_NOT_GENERATE = eINSTANCE.getGenerationSetting_DoNotGenerate();
 
 		/**
 		 * The meta object literal for the '{@link adaptorinterface.impl.ShapeImpl <em>Shape</em>}' class.

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/GenerationSetting.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/GenerationSetting.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.EObject;
  * <ul>
  *   <li>{@link adaptorinterface.GenerationSetting#getJavaClassPackageName <em>Java Class Package Name</em>}</li>
  *   <li>{@link adaptorinterface.GenerationSetting#getJavaFilesPath <em>Java Files Path</em>}</li>
+ *   <li>{@link adaptorinterface.GenerationSetting#isDoNotGenerate <em>Do Not Generate</em>}</li>
  * </ul>
  *
  * @see adaptorinterface.AdaptorinterfacePackage#getGenerationSetting()
@@ -73,5 +74,31 @@ public interface GenerationSetting extends EObject {
 	 * @generated
 	 */
 	void setJavaFilesPath(String value);
+
+	/**
+	 * Returns the value of the '<em><b>Do Not Generate</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Do Not Generate</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Do Not Generate</em>' attribute.
+	 * @see #setDoNotGenerate(boolean)
+	 * @see adaptorinterface.AdaptorinterfacePackage#getGenerationSetting_DoNotGenerate()
+	 * @model
+	 * @generated
+	 */
+	boolean isDoNotGenerate();
+
+	/**
+	 * Sets the value of the '{@link adaptorinterface.GenerationSetting#isDoNotGenerate <em>Do Not Generate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Do Not Generate</em>' attribute.
+	 * @see #isDoNotGenerate()
+	 * @generated
+	 */
+	void setDoNotGenerate(boolean value);
 
 } // GenerationSetting

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -1454,6 +1454,15 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getGenerationSetting_DoNotGenerate() {
+		return (EAttribute)generationSettingEClass.getEStructuralFeatures().get(2);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	@Override
 	public EClass getShape() {
 		return shapeEClass;
@@ -1819,6 +1828,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 		generationSettingEClass = createEClass(GENERATION_SETTING);
 		createEAttribute(generationSettingEClass, GENERATION_SETTING__JAVA_CLASS_PACKAGE_NAME);
 		createEAttribute(generationSettingEClass, GENERATION_SETTING__JAVA_FILES_PATH);
+		createEAttribute(generationSettingEClass, GENERATION_SETTING__DO_NOT_GENERATE);
 
 		shapeEClass = createEClass(SHAPE);
 
@@ -2024,6 +2034,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 		initEClass(generationSettingEClass, GenerationSetting.class, "GenerationSetting", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getGenerationSetting_JavaClassPackageName(), ecorePackage.getEString(), "javaClassPackageName", null, 0, 1, GenerationSetting.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getGenerationSetting_JavaFilesPath(), ecorePackage.getEString(), "javaFilesPath", null, 0, 1, GenerationSetting.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGenerationSetting_DoNotGenerate(), ecorePackage.getEBoolean(), "doNotGenerate", null, 0, 1, GenerationSetting.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(shapeEClass, Shape.class, "Shape", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/GenerationSettingImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/GenerationSettingImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
  * <ul>
  *   <li>{@link adaptorinterface.impl.GenerationSettingImpl#getJavaClassPackageName <em>Java Class Package Name</em>}</li>
  *   <li>{@link adaptorinterface.impl.GenerationSettingImpl#getJavaFilesPath <em>Java Files Path</em>}</li>
+ *   <li>{@link adaptorinterface.impl.GenerationSettingImpl#isDoNotGenerate <em>Do Not Generate</em>}</li>
  * </ul>
  *
  * @generated
@@ -66,6 +67,26 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 	 * @ordered
 	 */
 	protected String javaFilesPath = JAVA_FILES_PATH_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isDoNotGenerate() <em>Do Not Generate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isDoNotGenerate()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean DO_NOT_GENERATE_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isDoNotGenerate() <em>Do Not Generate</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isDoNotGenerate()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean doNotGenerate = DO_NOT_GENERATE_EDEFAULT;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -137,6 +158,27 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public boolean isDoNotGenerate() {
+		return doNotGenerate;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setDoNotGenerate(boolean newDoNotGenerate) {
+		boolean oldDoNotGenerate = doNotGenerate;
+		doNotGenerate = newDoNotGenerate;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE, oldDoNotGenerate, doNotGenerate));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
@@ -144,6 +186,8 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 				return getJavaClassPackageName();
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_FILES_PATH:
 				return getJavaFilesPath();
+			case AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE:
+				return isDoNotGenerate();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -161,6 +205,9 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 				return;
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_FILES_PATH:
 				setJavaFilesPath((String)newValue);
+				return;
+			case AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE:
+				setDoNotGenerate((Boolean)newValue);
 				return;
 		}
 		super.eSet(featureID, newValue);
@@ -180,6 +227,9 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_FILES_PATH:
 				setJavaFilesPath(JAVA_FILES_PATH_EDEFAULT);
 				return;
+			case AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE:
+				setDoNotGenerate(DO_NOT_GENERATE_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -196,6 +246,8 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 				return JAVA_CLASS_PACKAGE_NAME_EDEFAULT == null ? javaClassPackageName != null : !JAVA_CLASS_PACKAGE_NAME_EDEFAULT.equals(javaClassPackageName);
 			case AdaptorinterfacePackage.GENERATION_SETTING__JAVA_FILES_PATH:
 				return JAVA_FILES_PATH_EDEFAULT == null ? javaFilesPath != null : !JAVA_FILES_PATH_EDEFAULT.equals(javaFilesPath);
+			case AdaptorinterfacePackage.GENERATION_SETTING__DO_NOT_GENERATE:
+				return doNotGenerate != DO_NOT_GENERATE_EDEFAULT;
 		}
 		return super.eIsSet(featureID);
 	}
@@ -214,6 +266,8 @@ public class GenerationSettingImpl extends MinimalEObjectImpl.Container implemen
 		result.append(javaClassPackageName);
 		result.append(", javaFilesPath: ");
 		result.append(javaFilesPath);
+		result.append(", doNotGenerate: ");
+		result.append(doNotGenerate);
 		result.append(')');
 		return result.toString();
 	}

--- a/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
+++ b/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
@@ -76,8 +76,70 @@
               <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_gray']"/>
             </style>
           </subContainerMappings>
+          <subContainerMappings name="Specification.DomainSpecification.GenerationSetting" semanticCandidatesExpression="[self.generationSetting/]" domainClass="adaptorinterface.GenerationSetting" childrenPresentation="List">
+            <subNodeMappings name="Specification.DomainSpecification.GenerationSetting.javaClassPackageName" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+              <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Java Class Package Name: &quot;' + self.javaClassPackageName + '&quot;'/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+                <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              </style>
+            </subNodeMappings>
+            <subNodeMappings name="Specification.DomainSpecification.GenerationSetting.javaFilesPath" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+              <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Java Files Path: &quot;' + self.javaFilesPath + '&quot;'/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+                <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              </style>
+            </subNodeMappings>
+            <subNodeMappings name="Specification.DomainSpecification.GenerationSetting.doNotGenerate" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+              <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Do Not Generate: ' + self.doNotGenerate/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+                <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+                <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              </style>
+            </subNodeMappings>
+            <style xsi:type="style:FlatContainerStyleDescription" borderSizeComputationExpression="1" labelSize="12" showIcon="false" labelExpression="Generation Setting" backgroundStyle="Liquid">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelFormat>italic</labelFormat>
+              <labelFormat>underline</labelFormat>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+              <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+            </style>
+          </subContainerMappings>
           <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" borderSizeComputationExpression="1" labelSize="9" labelExpression="[self.name + ' (' + self.namespacePrefix.name + ')'/]" iconPath="/org.eclipse.lyo.tools.toolchain.design/images/IconAdaptor.png" widthComputationExpression="40" heightComputationExpression="30">
             <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </containerMappings>
+        <containerMappings name="Specification.GenerationSetting" semanticCandidatesExpression="[self.generationSetting/]" domainClass="adaptorinterface.GenerationSetting" childrenPresentation="List">
+          <subNodeMappings name="Specification.GenerationSetting.javaClassPackageName" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+            <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Java Class Package Name: &quot;' + self.javaClassPackageName + '&quot;'/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </style>
+          </subNodeMappings>
+          <subNodeMappings name="Specification.GenerationSetting.javaFilesPath" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+            <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Java Files Path: &quot;' + self.javaFilesPath + '&quot;'/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </style>
+          </subNodeMappings>
+          <subNodeMappings name="Specification.GenerationSetting.doNotGenerate" semanticCandidatesExpression="[self/]" domainClass="adaptorinterface.GenerationSetting">
+            <style xsi:type="style:BundledImageDescription" labelSize="12" showIcon="false" labelExpression="['Do Not Generate: ' + self.doNotGenerate/]" labelAlignment="LEFT" labelPosition="node" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </style>
+          </subNodeMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" borderSizeComputationExpression="1" labelSize="12" showIcon="false" labelExpression="Generation Setting" backgroundStyle="Liquid">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>italic</labelFormat>
+            <labelFormat>underline</labelFormat>
             <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
             <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
@@ -333,6 +395,15 @@
                 </firstModelOperations>
               </initialOperation>
             </menuItemDescription>
+          </ownedTools>
+        </toolSections>
+        <toolSections name="Config">
+          <ownedTools xsi:type="tool:ContainerCreationDescription" name="Specification.CreateGenerationSetting" label="Generation Setting" precondition="[self.generationSetting.oclIsUndefined()/]" containerMappings="//@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.GenerationSetting'] //@ownedViewpoints[name='ToolchainViewpoint']/@ownedRepresentations[name='SpecificationDiagram']/@defaultLayer/@containerMappings[name='Specification.DomainSpecification']/@subContainerMappings[name='Specification.DomainSpecification.GenerationSetting']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="adaptorinterface.GenerationSetting" referenceName="generationSetting"/>
+            </initialOperation>
           </ownedTools>
         </toolSections>
       </defaultLayer>


### PR DESCRIPTION
A "do-not-generate" true/false option is provided on a
domainSpecification and/Specification level. This controls whether java
classes are (re)produced.
A visual representation of any generation settings is also provided.
See picture below for illustration.

Tasks:
- [ ] Generate the necessary EMF classes, based on Eclipse Oxygen and java8.

![Capture](https://user-images.githubusercontent.com/7108694/72811937-eb464780-3c60-11ea-922b-1f293fdd5329.PNG)

