### PR TITLE
Import Vocabulary classes in the resource interface, the same way it is in the resource class.

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceInterface.mtl
@@ -23,13 +23,14 @@
  *******************************************************************************/
 /]
 
-[module generateResourceInterface('http://org.eclipse.lyo/oslc4j/adaptorInterface')]
+[module generateResourceInterface('http://org.eclipse.lyo/oslc4j/adaptorInterface', 'http://org.eclipse.lyo/oslc4j/vocabulary')]
 
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourcePropertyServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::adaptorInterfaceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
+[import org::eclipse::lyo::oslc4j::codegenerator::services::vocabularyServices/]
 
 [template public generateResourceInterface(aResource : Resource, contextAdaptorInterface : AdaptorInterface, managingAdaptorInterface: AdaptorInterface, defaultJavaFilesPath : String, defaultJavaClassPackageName : String)]
 [if (aResource.generate())]
@@ -98,6 +99,11 @@ import org.eclipse.lyo.oslc4j.core.model.ValueType;
 
 import [javaInterfaceFullNameForConstants(aResource.definingDomainSpecification(), contextAdaptorInterface, defaultJavaClassPackageName)/];
 [for (aDomainSpecification: DomainSpecification | (aResource.resourceProperties->union(aResource.interfaceProperties()->asSet())->collect(p: ResourceProperty | Set{p.definingDomainSpecification()}->union(p.range.definingDomainSpecification()->asSet())))->flatten()->asSet()->sortedBy(name)) separator(lineSeparator())]import [javaInterfaceFullNameForConstants(aDomainSpecification, contextAdaptorInterface, defaultJavaClassPackageName) /];[/for]
+[for (aVocabulary: Vocabulary | ((aResource.resourceProperties->asSequence())->union(interfaceProperties(aResource)))->asSet()
+        ->select(p: ResourceProperty | not (p.propertyDefinition.oclIsUndefined()))
+        ->collect(p: ResourceProperty | p.propertyDefinition.definingVocabulary())
+        ->flatten()->asSet()->sortedBy(name)) separator(lineSeparator())]import [javaInterfaceFullNameForConstants(aVocabulary, contextAdaptorInterface, defaultJavaClassPackageName) /];
+[/for]
 [for (aProperty: ResourceProperty | allProperties(aResource)->sortedBy(name))]
 [if(Sequence{'Resource', 'LocalResource'}->includes(aProperty.valueType.toString())) ]
 [for (r: Resource | aProperty.range)]


### PR DESCRIPTION
Import Vocabulary classes in the resource interface, the same way it is in the resource class.
Currently, generated code of more complex class structures does not compile.