### PR TITLE
Missing "return" statement causes requests (which function otherwise) to also cause an exception

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
@@ -523,6 +523,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
 
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[getResourceJspRelativeFileName(aResource, anAdaptorInterface) /]");
             rd.forward(httpServletRequest,httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
@@ -597,6 +598,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
             httpServletResponse.addHeader([javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].HDR_OSLC_VERSION, [javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].OSLC_VERSION_V2);
             addCORSHeaders(httpServletResponse);
             rd.forward(httpServletRequest, httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
@@ -623,6 +625,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
             httpServletResponse.addHeader([javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].HDR_OSLC_VERSION, [javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].OSLC_VERSION_V2);
             addCORSHeaders(httpServletResponse);
             rd.forward(httpServletRequest, httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceShapeService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceShapeService.mtl
@@ -119,7 +119,7 @@ public class [javaClassNameForResourceShapeService(anAdaptorInterface)/]
     @GET
     @Path("{resourceShapePath}")
     @Produces({ MediaType.TEXT_HTML })
-    public Response getResourceShapeAsHtml(
+    public void getResourceShapeAsHtml(
             @PathParam("resourceShapePath") final String resourceShapePath
         ) throws ServletException, IOException, URISyntaxException, OslcCoreApplicationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException
     {
@@ -133,6 +133,7 @@ public class [javaClassNameForResourceShapeService(anAdaptorInterface)/]
             
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[resourceShapeJspRelativeFileName(anAdaptorInterface) /]");
             rd.forward(httpServletRequest,httpServletResponse);
+            return;
         }
         throw new WebApplicationException(Status.NOT_FOUND);
     }

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderCatalogService.mtl
@@ -178,6 +178,7 @@ public class [javaClassNameForService(aServiceProviderCatalog) /]
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[serviceProviderCatalogJspRelativeFileName() /]");
             try {
                 rd.forward(httpServletRequest, httpServletResponse);
+                return;
             } catch (Exception e) {
                 e.printStackTrace();
                 throw new WebApplicationException(e);

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateServiceProviderService.mtl
@@ -165,6 +165,7 @@ public class [javaClassNameForService(aServiceProvider) /]
 
         RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[serviceProviderJspRelativeFileName(aServiceProvider) /]");
         rd.forward(httpServletRequest, httpServletResponse);
+        return;
     }
 }
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateWebService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateWebService.mtl
@@ -232,6 +232,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
 
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[getResourceJspRelativeFileName(aResource, anAdaptorInterface) /]");
             rd.forward(httpServletRequest,httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
@@ -306,6 +307,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
             httpServletResponse.addHeader([javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].HDR_OSLC_VERSION, [javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].OSLC_VERSION_V2);
             addCORSHeaders(httpServletResponse);
             rd.forward(httpServletRequest, httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);
@@ -332,6 +334,7 @@ import [javaClassFullName(aResource, anAdaptorInterface, null) /];
             httpServletResponse.addHeader([javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].HDR_OSLC_VERSION, [javaInterfaceNameForAdaptorConstants(anAdaptorInterface)/].OSLC_VERSION_V2);
             addCORSHeaders(httpServletResponse);
             rd.forward(httpServletRequest, httpServletResponse);
+            return;
         }
 
         throw new WebApplicationException(Status.NOT_FOUND);

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/serviceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/serviceServices.mtl
@@ -349,7 +349,7 @@ javaClassName(aResource)
 if forRDF then 
 	 aBasicCapability.getResourceMethodResourceType(aResource)
 else 
-	'Response' 
+	'void' 
 endif
 /]
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/webServiceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/webServiceServices.mtl
@@ -103,7 +103,7 @@ javaClassName(aResource)
 if forRDF then 
 	 aResource.getResourceMethodResourceType()
 else 
-	'Response' 
+	'void' 
 endif
 /]
 


### PR DESCRIPTION
For the web methods that handle html-requests, add a "return" statement after the statement that dispatches the call to the JSP pages.
Otherwise, the code continues to the part that throws a web exception - even when the the jsp page is being displayed fine.