### PR TITLE
Some improvements to the jsp/debug pages

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
@@ -67,6 +67,9 @@
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.OslcConstants"%>
 <%@page import="org.eclipse.lyo.oslc4j.core.OSLC4JUtils"%>
+<%@page import="org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition"%>
+<%@page import="org.eclipse.lyo.oslc4j.core.annotation.OslcName"%>
+<%@page import="java.lang.reflect.Method"%>
 <%@page import="java.net.URI"%>
 <%@page import="java.util.Collection"%>
 <%@page import="java.util.Date"%>
@@ -115,7 +118,7 @@
 <!-- Begin page content -->
 <div class="container">
     <div class="page-header">
-        <h1>[aResource.name /] resource</h1>
+        <h1>[aResource.name /]: <%= a[javaName(aResource, true)/].toString() %></h1>
         <%
         URI shapeUri = UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path(OslcConstants.PATH_RESOURCE_SHAPES).path([javaInterfaceNameForConstants(aResource.definingDomainSpecification())/].[resourcePathConstantName(aResource)/]).build();
         Collection<URI> types = a[javaName(aResource, true)/].getTypes();   
@@ -135,10 +138,12 @@
     </div>
         <h2>Properties</h2>
         <div>
+          <% Method method = null; %>
           [for (propertiesCollection: Collection(ResourceProperty) | Sequence{aResource.resourceProperties, inheritedProperties(aResource), interfaceProperties(aResource)})]
           [for (aProperty: ResourceProperty | propertiesCollection)]
           <dl class="row">
-            <dt  class="col-sm-2 text-right">[aProperty.name /]</dt>
+            <% method = [javaClassName(aResource)/].class.getMethod("[javaAttributeGetterMethodName(aProperty, aResource)/]"); %>
+            <dt  class="col-sm-2 text-right"><a href="<%=method.getAnnotation(OslcPropertyDefinition.class).value() %>"><%=method.getAnnotation(OslcName.class).value()%></a></dt>
             <dd class="col-sm-9">
             [propertyToHtml(aProperty, aResource, 'a'.concat(javaName(aResource, true)), contextAdaptorInterface) /]
             </dd>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
@@ -103,12 +103,12 @@
       <div class="alert alert-secondary" role="alert">
           Number of elements:&nbsp;
           <%= resources.size()%>
+          <% if (nextPageUri != null) { %><p><a href="<%= nextPageUri %>">Next Page</a></p><% } %>
       </div>
     </div>
         <% for ([queryMethodResourceType(aQueryCapability)/] aResource : resources) { %>
         <p><a href="<%= aResource.getAbout() %>" class="oslc-resource-link"><%=aResource.getAbout().toString()%></a><br /></p>
         <% } %>
-        <% if (nextPageUri != null) { %><a href="<%= nextPageUri %>">Next Page</a><% } %>
       </div>
   <footer class="footer">
       <div class="container">

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderHTML.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderHTML.mtl
@@ -108,7 +108,9 @@ Service['[]'/] services = (Service['[]'/])request.getAttribute("services");
       [/if]
     </div>
     <%for (int serviceIndex = 0; serviceIndex < services.length; serviceIndex++) {%>
+    <% URI domain = services['[serviceIndex]'/].getDomain();%>
     <h2>Service &#35;<%=serviceIndex%></h2>
+    (Domain: <a href="<%=domain%>"><%=domain%></a>)
     <% Dialog['[]'/] selectionDialogs = services['[serviceIndex]'/].getSelectionDialogs();%>
     <% if(selectionDialogs.length > 0) {%>
     <h4>Resource Selector Dialogs</h4>


### PR DESCRIPTION
- [ ] When listing the services of an SP, print out the domain of each
Service
- [ ] When listing the results of a query, show the "next" link at the top
of the page (instead of bottom of page).
- [ ] When listing the properties of a resource, change the label of each
property to be a URI (pointing to its vocabulary definition), instead of
just a a string.
- [ ] When presenting a particular resource, use its "toString()" at the
header.