### PR TITLE
add the egit feature and perspective.

### DIFF
--- a/org.eclipse.lyo.tools.designer.product/lyodesigner.product
+++ b/org.eclipse.lyo.tools.designer.product/lyodesigner.product
@@ -93,6 +93,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.lyo.tools.codegenerator.feature" installMode="root"/>
       <feature id="org.eclipse.lyo.tools.toolchain.feature" installMode="root"/>
       <feature id="org.eclipse.lyo.tools.designer.product.feature" installMode="root"/>
+      <feature id="org.eclipse.egit"/>
+      <feature id="org.eclipse.jgit"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
It is convenient to add the egit feature and perspective. Note that the Java perspective is already included, but not Java EE.

But where do we stop? 
Note that it is currently not possible to work with the generated Java code within LyoDesigner. 
But I am not sure if we want that?
* On one side, it would be nice that user can work in 1 environment.
* On the other, it would be smart to separate the 2 environments: 1 for modelling, and the other for Java development.

What do you think? Opinion appreciated.
