### PR TITLE
Store as plugin. Plus build fix

### DIFF
--- a/org.eclipse.lyo.oslc4j.plugins/category.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/category.xml
@@ -3,6 +3,9 @@
    <feature id="org.eclipse.lyo.oslc4j.implementations.plugin.feature">
       <category name="org.eclipse.lyo.oslc4j.osgi.bundles.category"/>
    </feature>
+   <feature id="org.eclipse.lyo.oslc4j.store.plugin.feature">
+      <category name="org.eclipse.lyo.oslc4j.osgi.bundles.category"/>
+   </feature>
    <feature id="org.eclipse.lyo.oslc4j.client.plugin.feature">
       <category name="org.eclipse.lyo.oslc4j.osgi.bundles.category"/>
    </feature>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>org.eclipse.lyo.oslc4j.plugins</artifactId>
     <packaging>pom</packaging>
     <properties>
-        <lyo.version>4.1.0-SNAPSOT</lyo.version>
+        <lyo.version>4.1.0-SNAPSHOT</lyo.version>
     </properties>
     <build>
         <plugins>
@@ -204,6 +204,92 @@
                                             </excludes>
                                         </artifact>
                                     </artifacts>
+                                </feature>
+                                <feature>
+                                    <id>org.eclipse.lyo.oslc4j.store.plugin.feature</id>
+                                    <version>${project.version}</version>
+                                    <label>Lyo Store</label>
+                                    <providerName>Eclipse Lyo</providerName>
+                                    <description url="https://www.eclipse.org/lyo/"> 
+                                        On OSGI bundle of Lyo Store, which is otherwise available under maven.
+                                    </description>
+                                    <copyright url="https://www.eclipse.org/lyo/">
+                                              Copyright (c) 2020 Eclipse contributors and others.
+                                        All rights reserved. This program and the accompanying materials
+                                        are made available under the terms of the Eclipse Public License
+                                        v1.0 and Eclipse Distribution License v. 1.0 which accompanies
+                                        this distribution.
+                                        The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+                                        and the Eclipse Distribution License is available at http://www.eclipse.org/org/documents/edl-v10.php.
+                                    </copyright>
+                                    <license url="https://eclipse.org/legal/epl/notice.php">
+                                              Eclipse Foundation Software User Agreement
+                                        
+                                        April 9, 2014
+                                        Usage Of Content
+                                        
+                                        THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY &quot;CONTENT&quot;). USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW. BY USING THE CONTENT, YOU AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW. IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.
+                                        Applicable Licenses
+                                        
+                                        Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 1.0 (&quot;EPL&quot;). A copy of the EPL is provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html. For purposes of the EPL, &quot;Program&quot; will mean the Content.
+                                        
+                                        Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code repository (&quot;Repository&quot;) in software modules (&quot;Modules&quot;) and made available as downloadable archives (&quot;Downloads&quot;).
+                                        
+                                            Content may be structured and packaged into modules to facilitate delivering, extending, and upgrading the Content. Typical modules may include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and features (&quot;Features&quot;).
+                                            Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java™ ARchive) in a directory named &quot;plugins&quot;.
+                                            A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material. Each Feature may be packaged as a sub-directory in a directory named &quot;features&quot;. Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of the Plug-ins and/or Fragments associated with that Feature.
+                                            Features may also include other Features (&quot;Included Features&quot;). Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of Included Features.
+                                        
+                                        The terms and conditions governing Plug-ins and Fragments should be contained in files named &quot;about.html&quot; (&quot;Abouts&quot;). The terms and conditions governing Features and Included Features should be contained in files named &quot;license.html&quot; (&quot;Feature Licenses&quot;). Abouts and Feature Licenses may be located in any directory of a Download or Module including, but not limited to the following locations:
+                                        
+                                            The top-level (root) directory
+                                            Plug-in and Fragment directories
+                                            Inside Plug-ins and Fragments packaged as JARs
+                                            Sub-directories of the directory named &quot;src&quot; of certain Plug-ins
+                                            Feature directories
+                                        
+                                        Note: if a Feature made available by the Eclipse Foundation is installed using the Provisioning Technology (as defined below), you must agree to a license (&quot;Feature Update License&quot;) during the installation process. If the Feature contains Included Features, the Feature Update License should either provide you with the terms and conditions governing the Included Features or inform you where you can locate them. Feature Update Licenses may be found in the &quot;license&quot; property of files named &quot;feature.properties&quot; found within a Feature. Such Abouts, Feature Licenses, and Feature Update Licenses contain the terms and conditions (or references to such terms and conditions) that govern your use of the associated Content in that directory.
+                                        
+                                        THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS. SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):
+                                        
+                                            Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)
+                                            Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)
+                                            Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)
+                                            Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)
+                                            Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)
+                                        
+                                        IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License is provided, please contact the Eclipse Foundation to determine what terms and conditions govern that particular Content.
+                                        Use of Provisioning Technology
+                                        
+                                        The Eclipse Foundation makes available provisioning software, examples of which include, but are not limited to, p2 and the Eclipse Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to install, extend and update Eclipse-based products. Information about packaging Installable Software is available at http://eclipse.org/equinox/p2/repository_packaging.html (&quot;Specification&quot;).
+                                        
+                                        You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the applicable license agreements relating to the Installable Software to be presented to, and accepted by, the users of the Provisioning Technology in accordance with the Specification. By using Provisioning Technology in such a manner and making it available in accordance with the Specification, you further acknowledge your agreement to, and the acquisition of all necessary rights to permit the following:
+                                        
+                                            A series of actions may occur (&quot;Provisioning Process&quot;) in which a user may execute the Provisioning Technology on a machine (&quot;Target Machine&quot;) with the intent of installing, extending or updating the functionality of an Eclipse-based product.
+                                            During the Provisioning Process, the Provisioning Technology may cause third party Installable Software or a portion thereof to be accessed and copied to the Target Machine.
+                                            Pursuant to the Specification, you will provide to the user the terms and conditions that govern the use of the Installable Software (&quot;Installable Software Agreement&quot;) and such Installable Software Agreement shall be accessed from the Target Machine in accordance with the Specification. Such Installable Software Agreement must inform the user of the terms and conditions that govern the Installable Software and must solicit acceptance by the end user in the manner prescribed in such Installable Software Agreement. Upon such indication of agreement by the user, the provisioning Technology will complete installation of the Installable Software.
+                                        
+                                        Cryptography
+                                        
+                                        Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country&apos;s laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
+                                        
+                                        Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
+                                    </license>
+                                    <artifacts>
+                                        <artifact><id>org.eclipse.lyo.store:store-core:${lyo.version}</id>
+                                            <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
+                                             Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.guava:::</exclude>
+                                                <exclude>xml-apis:xml-apis::</exclude>
+                                                <exclude>com.google.errorprone:::</exclude>
+                                                <exclude>com.google.j2objc:::</exclude>
+                                                <exclude>com.google.code.findbugs:::</exclude>
+                                            </excludes>
+                                        </artifact>
+                                     </artifacts>
                                 </feature>
                             </featureDefinitions>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <layout>p2</layout>
         </repository>
         <repository>
+            <id>acceleo</id>
+            <url>https://repo.eclipse.org/content/repositories/acceleo-releases/</url>
+        </repository>
+        <repository>
             <id>lyo-snapshots</id>
             <name>Eclipse Lyo Snapshots</name>
             <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -53,24 +53,12 @@
             <layout>p2</layout>
         </repository>
         <repository>
-            <id>acceleo</id>
-            <url>https://repo.eclipse.org/content/repositories/acceleo-releases/</url>
-        </repository>
-        <repository>
-            <id>lyo-releases</id>
-            <name>Eclipse Lyo Releases</name>
-            <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>lyo-snapshots</id>
             <name>Eclipse Lyo Snapshots</name>
             <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
Releasing LyoStore as a plugin.

Plus, the plugins have not been build since the release of 4.0.0. Why? 
1. 4.1.0-SNAPSOT is not a SNAPS**H**OT
2. Needed some cleaning of Repositories.