### PR TITLE
WIP - standalone generation

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.oslc4j.codegenerator/META-INF/MANIFEST.MF
@@ -15,7 +15,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.acceleo.model,
  org.eclipse.acceleo.profiler,
  org.eclipse.acceleo.engine,
- com.google.guava
+ com.google.guava,
+ org.eclipse.lyo.tools.adaptormodel.model,
+ org.eclipse.lyo.tools.toolchain.model,
+ org.eclipse.lyo.tools.vocabulary.model
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Eclipse-LazyStart: true

--- a/org.eclipse.lyo.oslc4j.codegenerator/build.properties
+++ b/org.eclipse.lyo.oslc4j.codegenerator/build.properties
@@ -1,5 +1,6 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               bin/
 customBuildCallbacks = build.acceleo

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/main/Generate.java
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/main/Generate.java
@@ -23,6 +23,9 @@ import org.eclipse.emf.common.util.Monitor;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import adaptorinterface.AdaptorinterfacePackage;
+import toolchain.ToolchainPackage;
+import vocabulary.VocabularyPackage;
 
 /**
  * Entry point of the 'Generate' generation module.
@@ -337,7 +340,7 @@ public class Generate extends AbstractAcceleoGenerator {
      * 
      * @param resourceSet
      *            The resource set which registry has to be updated.
-     * @generated
+     * @generated not
      */
     @Override
     public void registerPackages(ResourceSet resourceSet) {
@@ -377,6 +380,16 @@ public class Generate extends AbstractAcceleoGenerator {
          * 
          * To learn more about Package Registration, have a look at the Acceleo documentation (Help -> Help Contents).
          */
+        
+        if (!isInWorkspace(AdaptorinterfacePackage.class)) {
+             resourceSet.getPackageRegistry().put(AdaptorinterfacePackage.eNS_URI, AdaptorinterfacePackage.eINSTANCE);
+        }
+        if (!isInWorkspace(ToolchainPackage.class)) {
+            resourceSet.getPackageRegistry().put(ToolchainPackage.eNS_URI, ToolchainPackage.eINSTANCE);
+        }
+        if (!isInWorkspace(VocabularyPackage.class)) {
+            resourceSet.getPackageRegistry().put(VocabularyPackage.eNS_URI, VocabularyPackage.eINSTANCE);
+        }
     }
 
     /**

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/main/GenerateSpecification.java
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/main/GenerateSpecification.java
@@ -24,6 +24,10 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 
+import adaptorinterface.AdaptorinterfacePackage;
+import toolchain.ToolchainPackage;
+import vocabulary.VocabularyPackage;
+
 /**
  * Entry point of the 'GenerateSpecification' generation module.
  *
@@ -335,7 +339,7 @@ public class GenerateSpecification extends AbstractAcceleoGenerator {
      * 
      * @param resourceSet
      *            The resource set which registry has to be updated.
-     * @generated
+     * @generated not
      */
     @Override
     public void registerPackages(ResourceSet resourceSet) {
@@ -375,6 +379,16 @@ public class GenerateSpecification extends AbstractAcceleoGenerator {
          * 
          * To learn more about Package Registration, have a look at the Acceleo documentation (Help -> Help Contents).
          */
+
+        if (!isInWorkspace(AdaptorinterfacePackage.class)) {
+            resourceSet.getPackageRegistry().put(AdaptorinterfacePackage.eNS_URI, AdaptorinterfacePackage.eINSTANCE);
+        }
+        if (!isInWorkspace(ToolchainPackage.class)) {
+           resourceSet.getPackageRegistry().put(ToolchainPackage.eNS_URI, ToolchainPackage.eINSTANCE);
+        }
+        if (!isInWorkspace(VocabularyPackage.class)) {
+           resourceSet.getPackageRegistry().put(VocabularyPackage.eNS_URI, VocabularyPackage.eINSTANCE);
+        }
     }
 
     /**

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/OsgiServices.java
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/OsgiServices.java
@@ -19,6 +19,9 @@ import org.osgi.framework.Version;
 public class OsgiServices {
 
 	public String getOSGiBundleVersion() {
+        if (FrameworkUtil.getBundle(getClass()) == null) {
+            return "-1";
+        }
 		Version version = FrameworkUtil.getBundle(getClass()).getVersion();
 		return version.toString();
 	}


### PR DESCRIPTION
with the changes in this patch, I can run the generation as a java application. 
I can even copy the command from eclipse (below) and run it completely standalone from a batch file. 
But surely, we can package this better? I tried to "export fat jar" from Eclipse but faced some errors.

Otherwise, there is 1 TODO we need to deal with:
- [ ] I can no longer easily extract the OSGiBundleVersion(). We add the OSGI version to the Application class to indicate which version of Lyo we are running.

`javaw -classpath "C:\Users\jad\git\aide\lyo.designer\org.eclipse.lyo.oslc4j.codegenerator\target\classes;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.core.runtime_3.20.0.v20201027-1526.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.osgi_3.16.100.v20201030-1916.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.osgi.compatibility.state_1.2.200.v20200915-2015.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.equinox.common_3.14.0.v20201102-2053.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.core.jobs_3.10.1000.v20200909-1312.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.equinox.registry_3.10.0.v20201107-1818.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.equinox.preferences_3.8.100.v20201102-2042.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.core.contenttype_3.7.800.v20200724-0804.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.equinox.app_1.5.0.v20200717-0620.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.emf.ecore_2.23.0.v20200630-0516.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.emf.common_2.21.0.v20200917-1439.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.emf.ecore.xmi_2.16.0.v20190528-0725.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.ocl_3.15.100.v20201208-2229.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\lpg.runtime.java_2.0.17.v201004271640.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.ocl.common_1.8.500.v20201208-2229.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.ocl.ecore_3.15.100.v20201208-2229.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.acceleo.common_3.7.10.202002210922.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.acceleo.model_3.7.10.202002210922.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.acceleo.profiler_3.7.10.202002210922.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.acceleo.engine_3.7.10.202002210922.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.emf.codegen.ecore_2.24.0.v20200917-1423.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\org.eclipse.emf.codegen_2.21.0.v20200708-0547.jar;C:\Programs\eclipse\eclipse-2020-12-LyoDev\plugins\com.google.guava_27.1.0.v20190517-1946.jar;C:\Users\jad\git\aide\lyo.designer\org.eclipse.lyo.tools.vocabulary.model\bin;C:\Users\jad\git\aide\lyo.designer\org.eclipse.lyo.tools.adaptormodel.model\bin;C:\Users\jad\git\aide\lyo.designer\org.eclipse.lyo.tools.toolchain.model\bin;C:\Users\jad\.m2\repository\org\eclipse\lyo\tools\org.eclipse.lyo.oslc4j.adaptormodel\4.1.0-SNAPSHOT\org.eclipse.lyo.oslc4j.adaptormodel-4.1.0-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\lyo\tools\org.eclipse.lyo.tools.adaptormodel.model\4.1.0-SNAPSHOT\org.eclipse.lyo.tools.adaptormodel.model-4.1.0-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\lyo\tools\org.eclipse.lyo.tools.vocabulary.model\4.1.0-SNAPSHOT\org.eclipse.lyo.tools.vocabulary.model-4.1.0-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.acceleo.maven\3.6.4\org.eclipse.acceleo.maven-3.6.4.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-plugin-api\2.0\maven-plugin-api-2.0.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-project\2.0.8\maven-project-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-settings\2.0.8\maven-settings-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-profile\2.0.8\maven-profile-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-model\2.0.8\maven-model-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-artifact-manager\2.0.8\maven-artifact-manager-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-repository-metadata\2.0.8\maven-repository-metadata-2.0.8.jar;C:\Users\jad\.m2\repository\org\apache\maven\wagon\wagon-provider-api\1.0-beta-2\wagon-provider-api-1.0-beta-2.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-plugin-registry\2.0.8\maven-plugin-registry-2.0.8.jar;C:\Users\jad\.m2\repository\org\codehaus\plexus\plexus-utils\1.4.6\plexus-utils-1.4.6.jar;C:\Users\jad\.m2\repository\org\apache\maven\maven-artifact\2.0.8\maven-artifact-2.0.8.jar;C:\Users\jad\.m2\repository\org\codehaus\plexus\plexus-container-default\1.0-alpha-9-stable-1\plexus-container-default-1.0-alpha-9-stable-1.jar;C:\Users\jad\.m2\repository\junit\junit\3.8.1\junit-3.8.1.jar;C:\Users\jad\.m2\repository\classworlds\classworlds\1.1-alpha-2\classworlds-1.1-alpha-2.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.acceleo.parser\3.6.4-SNAPSHOT\org.eclipse.acceleo.parser-3.6.4-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.acceleo.model\3.6.4-SNAPSHOT\org.eclipse.acceleo.model-3.6.4-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.acceleo.common\3.6.4-SNAPSHOT\org.eclipse.acceleo.common-3.6.4-SNAPSHOT.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.emf.ecore\2.10.2.v20150123-0348\org.eclipse.emf.ecore-2.10.2.v20150123-0348.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.emf.ecore.xmi\2.10.2.v20150123-0348\org.eclipse.emf.ecore.xmi-2.10.2.v20150123-0348.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.emf.common\2.10.1.v20150123-0348\org.eclipse.emf.common-2.10.1.v20150123-0348.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.ocl.ecore\3.3.100.v20140610-0641\org.eclipse.ocl.ecore-3.3.100.v20140610-0641.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.ocl.common\1.2.0.v20140610-0641\org.eclipse.ocl.common-1.2.0.v20140610-0641.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.ocl\3.4.2.v20140725-2242\org.eclipse.ocl-3.4.2.v20140725-2242.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\lpg.runtime.java\2.0.17.v201004271640\lpg.runtime.java-2.0.17.v201004271640.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.core.contenttype\3.4.200.v20140207-1251\org.eclipse.core.contenttype-3.4.200.v20140207-1251.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.equinox.common\3.6.200.v20130402-1505\org.eclipse.equinox.common-3.6.200.v20130402-1505.jar;C:\Users\jad\.m2\repository\com\google\guava\guava\10.0.1\guava-10.0.1.jar;C:\Users\jad\.m2\repository\com\google\code\findbugs\jsr305\1.3.9\jsr305-1.3.9.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.core.runtime\3.10.0.v20140318-2214\org.eclipse.core.runtime-3.10.0.v20140318-2214.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.core.resources\3.9.1.v20140825-1431\org.eclipse.core.resources-3.9.1.v20140825-1431.jar;C:\Users\jad\.m2\repository\org\eclipse\acceleo\org.eclipse.acceleo.engine\3.5.1.201409021433\org.eclipse.acceleo.engine-3.5.1.201409021433.jar" org.eclipse.lyo.oslc4j.codegenerator.main.Generate C:/Users/jad/git/aide/lyo-adaptor-sample-modelling/toolchain-model/My.toolchain C:/Users/jad/git/aide/lyo-adaptor-sample-modelling/toolchain-model`