### PR TITLE
Setting the java heap size since Eclipse seems to default to a small size otherwise.

### DIFF
--- a/org.eclipse.lyo.tools.designer.product/lyodesigner.product
+++ b/org.eclipse.lyo.tools.designer.product/lyodesigner.product
@@ -7,6 +7,8 @@
    </configIni>
 
    <launcherArgs>
+      <vmArgs>-Xmx2048m
+      </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
    </launcherArgs>
@@ -23,7 +25,9 @@
    </launcher>
 
    <vm>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
    <license>


### PR DESCRIPTION
Setting the java heap size since Eclipse seems to default to a small size otherwise.
Also, stating explicitly that java-11 is needed.