### PR TITLE
Support for the new properties oslc:name and dcterms:description for a ResourceShape.

### DIFF
--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -144,6 +144,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         iD="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="title" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="describes" eType="ecore:EClass vocabulary.ecore#//Class"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="extends" upperBound="-1"
         eType="#//Resource"/>
@@ -153,8 +155,8 @@
   <eClassifiers xsi:type="ecore:EClass" name="ResourceProperty" eSuperTypes="#//ShapeProperty">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         iD="true"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="title" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="title" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="propertyDefinition" eType="ecore:EClass vocabulary.ecore#//Property"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="occurs" eType="#//ResourcePropertyOccurs"

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -146,6 +146,8 @@
     <genClasses ecoreClass="adaptorInterface.ecore#//Resource">
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//Resource/id"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//Resource/name"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//Resource/title"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//Resource/description"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/describes"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/extends"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/resourceProperties"/>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
@@ -60,7 +60,7 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-        <title><%= aResourceShape.getTitle() %></title>
+        <title><%= aResourceShape.getName() %></title>
 
         <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
         <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -88,22 +88,34 @@
     <div class="container">
             <div class="row">
                 <div class="col-md-12" id="page-index">
-                    <h1>Shape "<%=aResourceShape.getTitle()%>"</h1>
-                    
+                    <h1><%=aResourceShape.getName()%></h1>
                     <p class="lead">
-                      About URI:
-                      <code><%=aResourceShape.getAbout()%></code>
-                    </p>
-
-                    <h2>Describes</h2>
-                    <ul>
-                        <%for(URI next : aResourceShape.getDescribes()) {
+                      Describes:
+                      <%if(aResourceShape.getDescribes().length == 1) {%>
+                          <code><%=aResourceShape.getDescribes()['[0]'/]%></code>
+                      <%} else {%>
+                            <ul>
+                                <%for(URI next : aResourceShape.getDescribes()) {
                             String['[]'/] split = next.toString().split("['[#/]'/]+");
                             String shortName = (split.length > 1) ? split['[split.length -1]'/] : next.toString();
-                        %>
-                            <li><a href="<%=next%>"><%=shortName%></a></li>
-                        <%}%>
-                    </ul>
+                                %>
+                                    <li><a href="<%=next%>"><%=shortName%></a></li>
+                                <%}%>
+                            </ul>
+                      <%}%>
+                    </p>
+                    <%if(null != aResourceShape.getTitle()) {%>
+                    <p>
+                      <strong>Summary:</strong>
+                      <%=aResourceShape.getTitle()%>
+                    </p>
+                    <%}%>
+                    <%if(null != aResourceShape.getDescription()) {%>
+                    <p>
+                      <strong>Description:</strong>
+                      <%=aResourceShape.getDescription()%>
+                    </p>
+                    <%}%>
                     <h2>Properties</h2>
                     <table class="table">
                         <tr>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourceServices.mtl
@@ -210,12 +210,10 @@ resourceConstantName(aResource).concat('_TYPE')
 /]
 
 [query public resourceShapeAnnotation(aResource : Resource) : String = 
-'@OslcResourceShape(title = "'
-.concat(aResource.name).concat(' ').concat('Resource Shape')
-.concat('", describes = ')
-.concat(javaInterfaceNameForConstants(aResource.definingDomainSpecification()))
-.concat('.')
-.concat(resourceTypeConstantName(aResource))
+'@OslcResourceShape('
+.concat('title = "').concat((if (aResource.title.oclIsUndefined()) then (aResource.name.concat(' Shape')) else (aResource.title) endif)).concat('"')
+.concat((if (not aResource.description.oclIsUndefined()) then (', description = "'.concat(aResource.description).concat('"')) else ('') endif))
+.concat(', describes = ').concat(javaInterfaceNameForConstants(aResource.definingDomainSpecification())).concat('.').concat(resourceTypeConstantName(aResource))
 .concat(')')
 /]
 

--- a/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
@@ -248,3 +248,5 @@ _UI_WebServicePersistence_delete_feature = Delete
 _UI_WebServicePersistence_update_feature = Update
 _UI_ServerConfiguration_generateJspFilesForOslcUI_feature = Generate Jsp Files For Oslc UI
 _UI_Specification_name_feature = Name
+_UI_Resource_title_feature = Title
+_UI_Resource_description_feature = Description

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourceItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourceItemProvider.java
@@ -47,6 +47,8 @@ public class ResourceItemProvider
 
             addIdPropertyDescriptor(object);
             addNamePropertyDescriptor(object);
+            addTitlePropertyDescriptor(object);
+            addDescriptionPropertyDescriptor(object);
             addDescribesPropertyDescriptor(object);
             addExtendsPropertyDescriptor(object);
             addResourcePropertiesPropertyDescriptor(object);
@@ -99,6 +101,50 @@ public class ResourceItemProvider
     }
 
 	/**
+     * This adds a property descriptor for the Title feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    protected void addTitlePropertyDescriptor(Object object) {
+        itemPropertyDescriptors.add
+            (createItemPropertyDescriptor
+                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+                 getResourceLocator(),
+                 getString("_UI_Resource_title_feature"),
+                 getString("_UI_PropertyDescriptor_description", "_UI_Resource_title_feature", "_UI_Resource_type"),
+                 AdaptorinterfacePackage.Literals.RESOURCE__TITLE,
+                 true,
+                 false,
+                 false,
+                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+                 null,
+                 null));
+    }
+
+    /**
+     * This adds a property descriptor for the Description feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    protected void addDescriptionPropertyDescriptor(Object object) {
+        itemPropertyDescriptors.add
+            (createItemPropertyDescriptor
+                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+                 getResourceLocator(),
+                 getString("_UI_Resource_description_feature"),
+                 getString("_UI_PropertyDescriptor_description", "_UI_Resource_description_feature", "_UI_Resource_type"),
+                 AdaptorinterfacePackage.Literals.RESOURCE__DESCRIPTION,
+                 true,
+                 false,
+                 false,
+                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+                 null,
+                 null));
+    }
+
+    /**
      * This adds a property descriptor for the Extends feature.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -204,6 +250,8 @@ public class ResourceItemProvider
         switch (notification.getFeatureID(Resource.class)) {
             case AdaptorinterfacePackage.RESOURCE__ID:
             case AdaptorinterfacePackage.RESOURCE__NAME:
+            case AdaptorinterfacePackage.RESOURCE__TITLE:
+            case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
                 fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
@@ -1005,13 +1005,31 @@ public interface AdaptorinterfacePackage extends EPackage {
 	int RESOURCE__NAME = SHAPE_FEATURE_COUNT + 1;
 
 	/**
+     * The feature id for the '<em><b>Title</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     * @ordered
+     */
+    int RESOURCE__TITLE = SHAPE_FEATURE_COUNT + 2;
+
+    /**
+     * The feature id for the '<em><b>Description</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     * @ordered
+     */
+    int RESOURCE__DESCRIPTION = SHAPE_FEATURE_COUNT + 3;
+
+    /**
      * The feature id for the '<em><b>Describes</b></em>' reference.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      * @ordered
      */
-	int RESOURCE__DESCRIBES = SHAPE_FEATURE_COUNT + 2;
+	int RESOURCE__DESCRIBES = SHAPE_FEATURE_COUNT + 4;
 
 	/**
      * The feature id for the '<em><b>Extends</b></em>' reference list.
@@ -1020,7 +1038,7 @@ public interface AdaptorinterfacePackage extends EPackage {
      * @generated
      * @ordered
      */
-	int RESOURCE__EXTENDS = SHAPE_FEATURE_COUNT + 3;
+	int RESOURCE__EXTENDS = SHAPE_FEATURE_COUNT + 5;
 
 	/**
      * The feature id for the '<em><b>Resource Properties</b></em>' reference list.
@@ -1029,7 +1047,7 @@ public interface AdaptorinterfacePackage extends EPackage {
      * @generated
      * @ordered
      */
-	int RESOURCE__RESOURCE_PROPERTIES = SHAPE_FEATURE_COUNT + 4;
+	int RESOURCE__RESOURCE_PROPERTIES = SHAPE_FEATURE_COUNT + 6;
 
 	/**
      * The number of structural features of the '<em>Resource</em>' class.
@@ -1038,7 +1056,7 @@ public interface AdaptorinterfacePackage extends EPackage {
      * @generated
      * @ordered
      */
-	int RESOURCE_FEATURE_COUNT = SHAPE_FEATURE_COUNT + 5;
+	int RESOURCE_FEATURE_COUNT = SHAPE_FEATURE_COUNT + 7;
 
 	/**
      * The number of operations of the '<em>Resource</em>' class.
@@ -3724,6 +3742,28 @@ public interface AdaptorinterfacePackage extends EPackage {
 	EAttribute getResource_Name();
 
 	/**
+     * Returns the meta object for the attribute '{@link adaptorinterface.Resource#getTitle <em>Title</em>}'.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the meta object for the attribute '<em>Title</em>'.
+     * @see adaptorinterface.Resource#getTitle()
+     * @see #getResource()
+     * @generated
+     */
+    EAttribute getResource_Title();
+
+    /**
+     * Returns the meta object for the attribute '{@link adaptorinterface.Resource#getDescription <em>Description</em>}'.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the meta object for the attribute '<em>Description</em>'.
+     * @see adaptorinterface.Resource#getDescription()
+     * @see #getResource()
+     * @generated
+     */
+    EAttribute getResource_Description();
+
+    /**
      * Returns the meta object for the reference '{@link adaptorinterface.Resource#getDescribes <em>Describes</em>}'.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -5797,6 +5837,22 @@ public interface AdaptorinterfacePackage extends EPackage {
 		EAttribute RESOURCE__NAME = eINSTANCE.getResource_Name();
 
 		/**
+         * The meta object literal for the '<em><b>Title</b></em>' attribute feature.
+         * <!-- begin-user-doc -->
+         * <!-- end-user-doc -->
+         * @generated
+         */
+        EAttribute RESOURCE__TITLE = eINSTANCE.getResource_Title();
+
+        /**
+         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+         * <!-- begin-user-doc -->
+         * <!-- end-user-doc -->
+         * @generated
+         */
+        EAttribute RESOURCE__DESCRIPTION = eINSTANCE.getResource_Description();
+
+        /**
          * The meta object literal for the '<em><b>Describes</b></em>' reference feature.
          * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Resource.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Resource.java
@@ -15,6 +15,8 @@ import org.eclipse.emf.common.util.EList;
  * <ul>
  *   <li>{@link adaptorinterface.Resource#getId <em>Id</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getName <em>Name</em>}</li>
+ *   <li>{@link adaptorinterface.Resource#getTitle <em>Title</em>}</li>
+ *   <li>{@link adaptorinterface.Resource#getDescription <em>Description</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getDescribes <em>Describes</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getExtends <em>Extends</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getResourceProperties <em>Resource Properties</em>}</li>
@@ -78,6 +80,50 @@ public interface Resource extends Shape {
 	void setName(String value);
 
 	/**
+     * Returns the value of the '<em><b>Title</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the value of the '<em>Title</em>' attribute.
+     * @see #setTitle(String)
+     * @see adaptorinterface.AdaptorinterfacePackage#getResource_Title()
+     * @model
+     * @generated
+     */
+    String getTitle();
+
+    /**
+     * Sets the value of the '{@link adaptorinterface.Resource#getTitle <em>Title</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @param value the new value of the '<em>Title</em>' attribute.
+     * @see #getTitle()
+     * @generated
+     */
+    void setTitle(String value);
+
+    /**
+     * Returns the value of the '<em><b>Description</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the value of the '<em>Description</em>' attribute.
+     * @see #setDescription(String)
+     * @see adaptorinterface.AdaptorinterfacePackage#getResource_Description()
+     * @model
+     * @generated
+     */
+    String getDescription();
+
+    /**
+     * Sets the value of the '{@link adaptorinterface.Resource#getDescription <em>Description</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @param value the new value of the '<em>Description</em>' attribute.
+     * @see #getDescription()
+     * @generated
+     */
+    void setDescription(String value);
+
+    /**
      * Returns the value of the '<em><b>Extends</b></em>' reference list.
      * The list contents are of type {@link adaptorinterface.Resource}.
      * <!-- begin-user-doc -->

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -1234,12 +1234,32 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public EAttribute getResource_Title() {
+        return (EAttribute)resourceEClass.getEStructuralFeatures().get(2);
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public EAttribute getResource_Description() {
+        return (EAttribute)resourceEClass.getEStructuralFeatures().get(3);
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
 	@Override
     public EReference getResource_Describes() {
-        return (EReference)resourceEClass.getEStructuralFeatures().get(2);
+        return (EReference)resourceEClass.getEStructuralFeatures().get(4);
     }
 
 	/**
@@ -1249,7 +1269,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
      */
 	@Override
     public EReference getResource_Extends() {
-        return (EReference)resourceEClass.getEStructuralFeatures().get(3);
+        return (EReference)resourceEClass.getEStructuralFeatures().get(5);
     }
 
 	/**
@@ -1259,7 +1279,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
      */
 	@Override
     public EReference getResource_ResourceProperties() {
-        return (EReference)resourceEClass.getEStructuralFeatures().get(4);
+        return (EReference)resourceEClass.getEStructuralFeatures().get(6);
     }
 
 	/**
@@ -2650,6 +2670,8 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         resourceEClass = createEClass(RESOURCE);
         createEAttribute(resourceEClass, RESOURCE__ID);
         createEAttribute(resourceEClass, RESOURCE__NAME);
+        createEAttribute(resourceEClass, RESOURCE__TITLE);
+        createEAttribute(resourceEClass, RESOURCE__DESCRIPTION);
         createEReference(resourceEClass, RESOURCE__DESCRIBES);
         createEReference(resourceEClass, RESOURCE__EXTENDS);
         createEReference(resourceEClass, RESOURCE__RESOURCE_PROPERTIES);
@@ -2952,6 +2974,8 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         initEClass(resourceEClass, Resource.class, "Resource", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEAttribute(getResource_Id(), ecorePackage.getEString(), "id", null, 1, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getResource_Name(), ecorePackage.getEString(), "name", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEAttribute(getResource_Title(), ecorePackage.getEString(), "title", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEAttribute(getResource_Description(), ecorePackage.getEString(), "description", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getResource_Describes(), theVocabularyPackage.getClass_(), null, "describes", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getResource_Extends(), this.getResource(), null, "extends", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getResource_ResourceProperties(), this.getResourceProperty(), null, "resourceProperties", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourceImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourceImpl.java
@@ -28,6 +28,8 @@ import org.eclipse.emf.ecore.util.EObjectResolvingEList;
  * <ul>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getId <em>Id</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getName <em>Name</em>}</li>
+ *   <li>{@link adaptorinterface.impl.ResourceImpl#getTitle <em>Title</em>}</li>
+ *   <li>{@link adaptorinterface.impl.ResourceImpl#getDescription <em>Description</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getDescribes <em>Describes</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getExtends <em>Extends</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getResourceProperties <em>Resource Properties</em>}</li>
@@ -77,6 +79,46 @@ public class ResourceImpl extends ShapeImpl implements Resource {
 	protected String name = NAME_EDEFAULT;
 
 	/**
+     * The default value of the '{@link #getTitle() <em>Title</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getTitle()
+     * @generated
+     * @ordered
+     */
+    protected static final String TITLE_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getTitle() <em>Title</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getTitle()
+     * @generated
+     * @ordered
+     */
+    protected String title = TITLE_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getDescription()
+     * @generated
+     * @ordered
+     */
+    protected static final String DESCRIPTION_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getDescription()
+     * @generated
+     * @ordered
+     */
+    protected String description = DESCRIPTION_EDEFAULT;
+
+    /**
      * The cached value of the '{@link #getDescribes() <em>Describes</em>}' reference.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -175,6 +217,52 @@ public class ResourceImpl extends ShapeImpl implements Resource {
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public void setTitle(String newTitle) {
+        String oldTitle = title;
+        title = newTitle;
+        if (eNotificationRequired())
+            eNotify(new ENotificationImpl(this, Notification.SET, AdaptorinterfacePackage.RESOURCE__TITLE, oldTitle, title));
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public void setDescription(String newDescription) {
+        String oldDescription = description;
+        description = newDescription;
+        if (eNotificationRequired())
+            eNotify(new ENotificationImpl(this, Notification.SET, AdaptorinterfacePackage.RESOURCE__DESCRIPTION, oldDescription, description));
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -251,6 +339,10 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 return getId();
             case AdaptorinterfacePackage.RESOURCE__NAME:
                 return getName();
+            case AdaptorinterfacePackage.RESOURCE__TITLE:
+                return getTitle();
+            case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
+                return getDescription();
             case AdaptorinterfacePackage.RESOURCE__DESCRIBES:
                 if (resolve) return getDescribes();
                 return basicGetDescribes();
@@ -276,6 +368,12 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 return;
             case AdaptorinterfacePackage.RESOURCE__NAME:
                 setName((String)newValue);
+                return;
+            case AdaptorinterfacePackage.RESOURCE__TITLE:
+                setTitle((String)newValue);
+                return;
+            case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
+                setDescription((String)newValue);
                 return;
             case AdaptorinterfacePackage.RESOURCE__DESCRIBES:
                 setDescribes((vocabulary.Class)newValue);
@@ -306,6 +404,12 @@ public class ResourceImpl extends ShapeImpl implements Resource {
             case AdaptorinterfacePackage.RESOURCE__NAME:
                 setName(NAME_EDEFAULT);
                 return;
+            case AdaptorinterfacePackage.RESOURCE__TITLE:
+                setTitle(TITLE_EDEFAULT);
+                return;
+            case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
+                setDescription(DESCRIPTION_EDEFAULT);
+                return;
             case AdaptorinterfacePackage.RESOURCE__DESCRIBES:
                 setDescribes((vocabulary.Class)null);
                 return;
@@ -331,6 +435,10 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
             case AdaptorinterfacePackage.RESOURCE__NAME:
                 return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+            case AdaptorinterfacePackage.RESOURCE__TITLE:
+                return TITLE_EDEFAULT == null ? title != null : !TITLE_EDEFAULT.equals(title);
+            case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
+                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
             case AdaptorinterfacePackage.RESOURCE__DESCRIBES:
                 return describes != null;
             case AdaptorinterfacePackage.RESOURCE__EXTENDS:
@@ -355,6 +463,10 @@ public class ResourceImpl extends ShapeImpl implements Resource {
         result.append(id);
         result.append(", name: ");
         result.append(name);
+        result.append(", title: ");
+        result.append(title);
+        result.append(", description: ");
+        result.append(description);
         result.append(')');
         return result.toString();
     }

--- a/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
+++ b/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
@@ -2096,11 +2096,6 @@
     <categories name="Default Category">
       <pages name="Default Page" labelExpression="aql:input.emfEditServices(self).getTabName()" domainClass="adaptorinterface.ResourceProperty" semanticCandidateExpression="var:self" groups="//@extensions.2/@categories.0/@groups.0"/>
       <groups name="Default Group" labelExpression="Properties" domainClass="adaptorinterface.ResourceProperty" semanticCandidateExpression="var:self">
-        <controls xsi:type="properties:TextDescription" name="adaptorinterface::ResourceProperty title" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('title')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('title'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('title').changeable" valueExpression="aql:self.title">
-          <initialOperation>
-            <firstModelOperations xsi:type="tool_1:SetValue" featureName="title" valueExpression="var:newValue"/>
-          </initialOperation>
-        </controls>
         <controls xsi:type="properties:TextDescription" name="adaptorinterface::ResourceProperty name" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('name')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('name'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('name').changeable" valueExpression="aql:self.name">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="var:newValue"/>
@@ -2110,6 +2105,11 @@
               <labelFontFormat>bold</labelFontFormat>
             </style>
           </conditionalStyles>
+        </controls>
+        <controls xsi:type="properties:TextDescription" name="adaptorinterface::ResourceProperty title" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('title')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('title'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('title').changeable" valueExpression="aql:self.title">
+          <initialOperation>
+            <firstModelOperations xsi:type="tool_1:SetValue" featureName="title" valueExpression="var:newValue"/>
+          </initialOperation>
         </controls>
         <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::ResourceProperty description" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('description')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('description'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('description').changeable" valueExpression="aql:self.description">
           <initialOperation>
@@ -2162,6 +2162,16 @@
         <controls xsi:type="properties:TextDescription" name="adaptorinterface::Resource name" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('name')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('name'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('name').changeable" valueExpression="aql:self.name">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="name" valueExpression="var:newValue"/>
+          </initialOperation>
+        </controls>
+        <controls xsi:type="properties:TextDescription" name="adaptorinterface::Resource title" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('title')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('title'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('title').changeable" valueExpression="aql:self.title">
+          <initialOperation>
+            <firstModelOperations xsi:type="tool_1:SetValue" featureName="title" valueExpression="var:newValue"/>
+          </initialOperation>
+        </controls>
+        <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::Resource description" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('description')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('description'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('description').changeable" valueExpression="aql:self.description">
+          <initialOperation>
+            <firstModelOperations xsi:type="tool_1:SetValue" featureName="description" valueExpression="var:newValue"/>
           </initialOperation>
         </controls>
         <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource describes" referenceNameExpression="aql:'describes'"/>


### PR DESCRIPTION
closes #196

Support for the new properties oslc:name and dcterms:description for a ResourceShape.
This is ultimately shown in the JSP page that shows information about a resource shape.

This change assumes the latest change in LyoCore is approved (https://github.com/eclipse/lyo/pull/204)

![image](https://user-images.githubusercontent.com/7108694/134741593-60120dce-af6e-4c8a-997a-90723e2f0cae.png)
