### PR TITLE
Consistent support for query parameters (prefix, where, paging)

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
@@ -174,7 +174,7 @@ public class [javaClassNameForAdaptorManager(anAdaptorInterface) /] {
 
     [for (aService: Service | anAdaptorInterface.serviceProviders().services)]
     [for (aQueryCapability: QueryCapability | aService.queryCapabilities)]
-    public static List<[queryMethodResourceType(aQueryCapability)/]> [queryMethodName(aQueryCapability, true)/](HttpServletRequest httpServletRequest[commaSeparate(queryMethodSignature(aQueryCapability, false), true, false)/], String where, String prefix, int page, int limit)
+    public static List<[queryMethodResourceType(aQueryCapability)/]> [queryMethodName(aQueryCapability, true)/](HttpServletRequest httpServletRequest[commaSeparate(queryMethodSignature(aQueryCapability, false), true, false)/], String where, String prefix, boolean paging, int page, int limit)
     {
         List<[queryMethodResourceType(aQueryCapability)/]> resources = null;
         [backendCode(anAdaptorInterface.backendCodeTemplate_getResources, queryMethodResourceType(aQueryCapability), 'resources', queryCompositeID(aQueryCapability))/]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
@@ -207,11 +207,16 @@ public class [javaClassName(aService) /]
                                                     [commaSeparate(queryMethodSignature(aQueryCapability, true), false, true) /]
                                                      @QueryParam("oslc.where") final String where,
                                                      @QueryParam("oslc.prefix") final String prefix,
+                                                     @QueryParam("oslc.paging") final String pagingString,
                                                      @QueryParam("page") final String pageString,
-                                                    @QueryParam("oslc.pageSize") final String pageSizeString) throws IOException, ServletException
+                                                     @QueryParam("oslc.pageSize") final String pageSizeString) throws IOException, ServletException
     {
+        boolean paging=false;
         int page=0;
         int pageSize=20;
+        if (null != pagingString) {
+            paging = Boolean.parseBoolean(pagingString);
+        }
         if (null != pageString) {
             page = Integer.parseInt(pageString);
         }
@@ -223,13 +228,22 @@ public class [javaClassName(aService) /]
         // Here additional logic can be implemented that complements main action taken in [javaClassNameForAdaptorManager(anAdaptorInterface) /]
         // [/protected]
 
-        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, page, pageSize);
-        httpServletRequest.setAttribute("queryUri",
-                uriInfo.getAbsolutePath().toString() + "?oslc.paging=true");
+        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
+        UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getAbsolutePath())
+            .queryParam("oslc.paging", "true")
+            .queryParam("oslc.pageSize", pageSize)
+            .queryParam("page", page);
+        if (null != where) {
+            uriBuilder.queryParam("oslc.where", where);
+        }
+        if (null != prefix) {
+            uriBuilder.queryParam("oslc.prefix", prefix);
+        }
+        httpServletRequest.setAttribute("queryUri", uriBuilder.build().toString());
         if (resources.size() > pageSize) {
             resources.remove(resources.size() - 1);
-            httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE,
-                    uriInfo.getAbsolutePath().toString() + "?oslc.paging=true&oslc.pageSize=" + pageSize + "&page=" + (page + 1));
+            uriBuilder.replaceQueryParam("page", page + 1);
+            httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE, uriBuilder.build().toString());
         }
         return resources.toArray(new [queryMethodResourceType(aQueryCapability) /] [ '[' /]resources.size()[ ']' /]);
     }
@@ -242,11 +256,16 @@ public class [javaClassName(aService) /]
                                     [commaSeparate(queryMethodSignature(aQueryCapability, true), false, true)/]
                                        @QueryParam("oslc.where") final String where,
                                        @QueryParam("oslc.prefix") final String prefix,
+                                       @QueryParam("oslc.paging") final String pagingString,
                                        @QueryParam("page") final String pageString,
-                                    @QueryParam("oslc.pageSize") final String pageSizeString) throws ServletException, IOException
+                                       @QueryParam("oslc.pageSize") final String pageSizeString) throws ServletException, IOException
     {
+        boolean paging=false;
         int page=0;
         int pageSize=20;
+        if (null != pagingString) {
+            paging = Boolean.parseBoolean(pagingString);
+        }
         if (null != pageString) {
             page = Integer.parseInt(pageString);
         }
@@ -257,25 +276,34 @@ public class [javaClassName(aService) /]
         // [protected (queryMethodName(aQueryCapability, false))]
         // [/protected]
 
-        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, page, pageSize);
+        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
 
         if (resources!= null) {
             httpServletRequest.setAttribute("resources", resources);
             // [protected (queryMethodName(aQueryCapability, false).concat('_setAttributes'))]
             // [/protected]
 
-            httpServletRequest.setAttribute("queryUri",
-                    uriInfo.getAbsolutePath().toString() + "?oslc.paging=true");
+            UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getAbsolutePath())
+                .queryParam("oslc.paging", "true")
+                .queryParam("oslc.pageSize", pageSize)
+                .queryParam("page", page);
+            if (null != where) {
+                uriBuilder.queryParam("oslc.where", where);
+            }
+            if (null != prefix) {
+                uriBuilder.queryParam("oslc.prefix", prefix);
+            }
+            httpServletRequest.setAttribute("queryUri", uriBuilder.build().toString());
             if (resources.size() > pageSize) {
                 resources.remove(resources.size() - 1);
-                httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE,
-                        uriInfo.getAbsolutePath().toString() + "?oslc.paging=true&oslc.pageSize=" + pageSize + "&page=" + (page + 1));
+
+                uriBuilder.replaceQueryParam("page", page + 1);
+                httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE, uriBuilder.build().toString());
             }
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[resourceCollectionJspRelativeFileName(aQueryCapability) /]");
             rd.forward(httpServletRequest,httpServletResponse);
             return;
         }
-
         throw new WebApplicationException(Status.NOT_FOUND);
     }
 


### PR DESCRIPTION
closes #203.
Besides oslc.paging, the remaining queryParameters (oslc.where and
oslc.prefix) are also consistently handled.