### PR TITLE
A cleaner way to identify and adjust the size of a queryresult.

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/config/generatePomXml.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/config/generatePomXml.mtl
@@ -112,7 +112,6 @@
     <groupId>javax.servlet</groupId>
     <artifactId>jstl</artifactId>
     <version>1.2</version>
-    <scope>provided</scope>
 </dependency>
 [if serverImplementation]
 <dependency>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateResourceService.mtl
@@ -240,7 +240,7 @@ public class [javaClassName(aService) /]
         // Here additional logic can be implemented that complements main action taken in [javaClassNameForAdaptorManager(anAdaptorInterface) /]
         // [/protected]
 
-        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
+        List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
         UriBuilder uriBuilder = UriBuilder.fromUri(uriInfo.getAbsolutePath())
             .queryParam("oslc.paging", "true")
             .queryParam("oslc.pageSize", pageSize)
@@ -253,7 +253,7 @@ public class [javaClassName(aService) /]
         }
         httpServletRequest.setAttribute("queryUri", uriBuilder.build().toString());
         if (resources.size() > pageSize) {
-            resources.remove(resources.size() - 1);
+            resources = resources.subList(0, pageSize);
             uriBuilder.replaceQueryParam("page", page + 1);
             httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE, uriBuilder.build().toString());
         }
@@ -288,10 +288,9 @@ public class [javaClassName(aService) /]
         // [protected (queryMethodName(aQueryCapability, false))]
         // [/protected]
 
-        final List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
+        List<[queryMethodResourceType(aQueryCapability)/]> resources = [javaClassNameForAdaptorManager(anAdaptorInterface) /].[queryMethodName(aQueryCapability, true)/](httpServletRequest[commaSeparate(queryMethodParameterList(aQueryCapability), true, false)/], where, prefix, paging, page, pageSize);
 
         if (resources!= null) {
-            httpServletRequest.setAttribute("resources", resources);
             // [protected (queryMethodName(aQueryCapability, false).concat('_setAttributes'))]
             // [/protected]
 
@@ -307,11 +306,12 @@ public class [javaClassName(aService) /]
             }
             httpServletRequest.setAttribute("queryUri", uriBuilder.build().toString());
             if (resources.size() > pageSize) {
-                resources.remove(resources.size() - 1);
+                resources = resources.subList(0, pageSize);
 
                 uriBuilder.replaceQueryParam("page", page + 1);
                 httpServletRequest.setAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE, uriBuilder.build().toString());
             }
+            httpServletRequest.setAttribute("resources", resources);
             RequestDispatcher rd = httpServletRequest.getRequestDispatcher("[resourceCollectionJspRelativeFileName(aQueryCapability) /]");
             rd.forward(httpServletRequest,httpServletResponse);
             return;


### PR DESCRIPTION
A cleaner way to identify and adjust the size of a queryresult.
Also changed the JSTL dependency scopt to NOT being "provided".


Signed-off-by: Jad El-khoury <jad.el.khoury@scania.com>