### PR TITLE
Migrating to simpler class names for Manager and ResourcesFactory class.

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorManager.mtl
@@ -67,6 +67,21 @@ endif)
 
 package [javaClassPackageNameForAdaptorManager(anAdaptorInterface) /];
 
+[if oldJavaClassNameForAdaptorManagerIsUsed(anAdaptorInterface)]
+// [protected ('Notice')]
+//Note: The Lyo code generator is migrating the name of this class from '[oldJavaClassNameForAdaptorManager(anAdaptorInterface)/]' to the new shorter name '[newJavaClassNameForAdaptorManager(anAdaptorInterface)/]'.
+//You are still using the old name. The generator will continue to use this old name until you actively trigger the change.
+//To migrate to the new class name:
+//1. Rename your class to [newJavaClassNameForAdaptorManager(anAdaptorInterface)/] 
+//    * Please rename and do not simply create a copy of the file. The generator needs to detect the file deletion in order to activate the name change.
+//2. Regenerate the code. 
+//    * The generator will generate this class with the new name.
+//    * Besides the class name, the code - including the user clode blocks - remain intact.
+//    * All other class references to the new class name are updated.
+//3. Delete this notice
+// [/protected]
+[/if]
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.ServletContextEvent;
 import java.util.List;

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorResourcesFactory.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorResourcesFactory.mtl
@@ -127,6 +127,21 @@ public static Link [constructLinkMethodName(aResource, aWebService)/]([commaSepa
 
 package [javaClassPackageNameForResourcesFactory(anAdaptorInterface) /];
 
+[if oldJavaClassNameForResourcesFactoryIsUsed(anAdaptorInterface)]
+// [protected ('Notice')]
+//Note: The Lyo code generator is migrating the name of this class from '[oldJavaClassNameForResourcesFactory(anAdaptorInterface)/]' to the new shorter name '[newJavaClassNameForResourcesFactory(anAdaptorInterface)/]'.
+//You are still using the old name. The generator will continue to use this old name until you actively trigger the change.
+//To migrate to the new class name:
+//1. Rename your class to [newJavaClassNameForResourcesFactory(anAdaptorInterface)/] 
+//    * Please rename and do not simply create a copy of the file. The generator needs to detect the file deletion in order to activate the name change.
+//2. Regenerate the code. 
+//    * The generator will generate this class with the new name.
+//    * Besides the class name, the code - including the user clode blocks - remain intact.
+//    * All other class references to the new class name are updated.
+//3. Delete this notice
+// [/protected]
+[/if]
+
 [generateImports(anAdaptorInterface)/]
 
 // [protected ('pre_class_code')]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -17,6 +17,7 @@
 [module adaptorInterfaceServices('http://org.eclipse.lyo/oslc4j/adaptorInterface', 'http://org.eclipse.lyo/oslc4j/vocabulary')/]
 
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
+[import org::eclipse::lyo::oslc4j::codegenerator::services::fileServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::serviceProviderServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
@@ -370,8 +371,24 @@ javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaClassPackageNameForAd
 javaBasePackageName(anAdaptorInterface)
 /]
 
-[query public javaClassNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
+[query public oldJavaClassNameForResourcesFactoryIsUsed(anAdaptorInterface : AdaptorInterface) : Boolean = 
+fileExists(oldJavaClassFullFileNameForResourcesFactory(anAdaptorInterface))
+/]
+
+[query public oldJavaClassNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
 javaName(anAdaptorInterface, true).concat('ResourcesFactory')
+/]
+
+[query public newJavaClassNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
+'ResourcesFactory'
+/]
+
+[query public javaClassNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
+(if (oldJavaClassNameForResourcesFactoryIsUsed(anAdaptorInterface)) then
+    oldJavaClassNameForResourcesFactory(anAdaptorInterface)
+else
+    newJavaClassNameForResourcesFactory(anAdaptorInterface)
+endif)
 /]
 
 [query public javaClassFullNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
@@ -382,13 +399,33 @@ javaClassPackageNameForResourcesFactory(anAdaptorInterface).concat('.').concat(j
 javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaClassPackageNameForResourcesFactory(anAdaptorInterface).substituteAll('.', '/')).concat('/').concat(javaClassNameForResourcesFactory(anAdaptorInterface)).concat('.java')
 /]
 
+[query public oldJavaClassFullFileNameForResourcesFactory(anAdaptorInterface : AdaptorInterface) : String = 
+javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaClassPackageNameForResourcesFactory(anAdaptorInterface).substituteAll('.', '/')).concat('/').concat(oldJavaClassNameForResourcesFactory(anAdaptorInterface)).concat('.java')
+/]
+
 [comment Services for AdaptorManager /]
 [query public javaClassPackageNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
 javaBasePackageName(anAdaptorInterface)
 /]
 
-[query public javaClassNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
+[query public oldJavaClassNameForAdaptorManagerIsUsed(anAdaptorInterface : AdaptorInterface) : Boolean = 
+fileExists(oldJavaClassFullFileNameForAdaptorManager(anAdaptorInterface))
+/]
+
+[query public oldJavaClassNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
 javaName(anAdaptorInterface, true).concat('Manager')
+/]
+
+[query public newJavaClassNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
+'RestDelegate'
+/]
+
+[query public javaClassNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
+(if (oldJavaClassNameForAdaptorManagerIsUsed(anAdaptorInterface)) then
+    oldJavaClassNameForAdaptorManager(anAdaptorInterface)
+else
+    newJavaClassNameForAdaptorManager(anAdaptorInterface)
+endif)
 /]
 
 [query public javaClassFullNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
@@ -397,6 +434,10 @@ javaClassPackageNameForAdaptorManager(anAdaptorInterface).concat('.').concat(jav
 
 [query public javaClassFullFileNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
 javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaClassPackageNameForAdaptorManager(anAdaptorInterface).substituteAll('.', '/')).concat('/').concat(javaClassNameForAdaptorManager(anAdaptorInterface)).concat('.java')
+/]
+
+[query public oldJavaClassFullFileNameForAdaptorManager(anAdaptorInterface : AdaptorInterface) : String = 
+javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaClassPackageNameForAdaptorManager(anAdaptorInterface).substituteAll('.', '/')).concat('/').concat(oldJavaClassNameForAdaptorManager(anAdaptorInterface)).concat('.java')
 /]
 
 [comment Services for ResourceShapeService /]


### PR DESCRIPTION

We want to migrate to simpler class names for Manager and ResourcesFactory class. The names should not contain the name of the applciation name in the class name. Just RestDelegate and ResourcesFactory only.

See the 4 commits in the branch https://github.com/OSLC/lyo-adaptor-sample-modelling/tree/simpler_class_names

Commit0. just basic pre-feature changes.
Commit1. Generator produces a notice to ask user to migrate the old names
Commit2. Manual changes for class renaming according to written instrutions.
Commit3. Generation after renaming, illustrating the little changes that are produced.
