### PR TITLE
adding an optional "additionalConstraints" text attribute on resource Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+- added an optional "additionalConstraints" multi-line text attribute on Resources and ResourceProperties. 
 ### Changed
 
 - `LYO_BASE` is replaced with `LYO_BASEURL`. To override the Base URL of the adaptor, use the `baseurl` property. This release makes the use of this property consistent and check the `LYO_BASEURL` environment variable instead of `LYO_BASE`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- added an optional "additionalConstraints" multi-line text attribute on Resources and ResourceProperties. 
+- added an optional "additionalConstraints" multi-line text attribute on Resources and ResourceProperties. The semantics of these properties This results in no code generation changes.
 ### Changed
 
 - `LYO_BASE` is replaced with `LYO_BASEURL`. To override the Base URL of the adaptor, use the `baseurl` property. This release makes the use of this property consistent and check the `LYO_BASEURL` environment variable instead of `LYO_BASE`.

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -178,6 +178,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="allowedValue" upperBound="-1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="isMemberProperty" eType="#//ResourcePropertyIsMemberProperty"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="additionalConstraints"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="ResourcePropertyOccurs">
     <eLiterals name="exactlyOne" literal="exactlyOne"/>

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.ecore
@@ -157,6 +157,8 @@
         eType="#//Resource"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="resourceProperties" upperBound="-1"
         eType="#//ResourceProperty"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="additionalConstraints"
+        upperBound="-1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="ResourceProperty" eSuperTypes="#//ShapeProperty">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -169,6 +169,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/multiValueRepresentation"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/allowedValue"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/isMemberProperty"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/additionalConstraints"/>
     </genClasses>
     <genClasses ecoreClass="adaptorInterface.ecore#//CreationFactory">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//CreationFactory/title"/>

--- a/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/model/adaptorInterface.genmodel
@@ -154,6 +154,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/describes"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/extends"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference adaptorInterface.ecore#//Resource/resourceProperties"/>
+      <genFeatures createChild="false" propertyMultiLine="true" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//Resource/additionalConstraints"/>
     </genClasses>
     <genClasses ecoreClass="adaptorInterface.ecore#//ResourceProperty">
       <genFeatures property="Readonly" createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/id"/>
@@ -169,7 +170,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/multiValueRepresentation"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/allowedValue"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/isMemberProperty"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/additionalConstraints"/>
+      <genFeatures createChild="false" propertyMultiLine="true" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//ResourceProperty/additionalConstraints"/>
     </genClasses>
     <genClasses ecoreClass="adaptorInterface.ecore#//CreationFactory">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute adaptorInterface.ecore#//CreationFactory/title"/>

--- a/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
@@ -258,3 +258,4 @@ _UI_WebService_sourceBinding_feature = Source Binding
 _UI_SourceBinding_source_feature = Source
 _UI_AdaptorInterface_sources_feature = Sources
 _UI_ResourceProperty_additionalConstraints_feature = Additional Constraints
+_UI_Resource_additionalConstraints_feature = Additional Constraints

--- a/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/plugin.properties
@@ -257,3 +257,4 @@ _UI_Service_sourceBinding_feature = Source Binding
 _UI_WebService_sourceBinding_feature = Source Binding
 _UI_SourceBinding_source_feature = Source
 _UI_AdaptorInterface_sources_feature = Sources
+_UI_ResourceProperty_additionalConstraints_feature = Additional Constraints

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourceItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourceItemProvider.java
@@ -52,6 +52,7 @@ public class ResourceItemProvider
             addDescribesPropertyDescriptor(object);
             addExtendsPropertyDescriptor(object);
             addResourcePropertiesPropertyDescriptor(object);
+            addAdditionalConstraintsPropertyDescriptor(object);
         }
         return itemPropertyDescriptors;
     }
@@ -189,6 +190,28 @@ public class ResourceItemProvider
     }
 
 	/**
+     * This adds a property descriptor for the Additional Constraints feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    protected void addAdditionalConstraintsPropertyDescriptor(Object object) {
+        itemPropertyDescriptors.add
+            (createItemPropertyDescriptor
+                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+                 getResourceLocator(),
+                 getString("_UI_Resource_additionalConstraints_feature"),
+                 getString("_UI_PropertyDescriptor_description", "_UI_Resource_additionalConstraints_feature", "_UI_Resource_type"),
+                 AdaptorinterfacePackage.Literals.RESOURCE__ADDITIONAL_CONSTRAINTS,
+                 true,
+                 true,
+                 false,
+                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+                 null,
+                 null));
+    }
+
+    /**
      * This adds a property descriptor for the Describes feature.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -252,6 +275,7 @@ public class ResourceItemProvider
             case AdaptorinterfacePackage.RESOURCE__NAME:
             case AdaptorinterfacePackage.RESOURCE__TITLE:
             case AdaptorinterfacePackage.RESOURCE__DESCRIPTION:
+            case AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS:
                 fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourcePropertyItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourcePropertyItemProvider.java
@@ -53,6 +53,7 @@ public class ResourcePropertyItemProvider extends ShapePropertyItemProvider {
             addMultiValueRepresentationPropertyDescriptor(object);
             addAllowedValuePropertyDescriptor(object);
             addIsMemberPropertyPropertyDescriptor(object);
+            addAdditionalConstraintsPropertyDescriptor(object);
         }
         return itemPropertyDescriptors;
     }
@@ -344,6 +345,28 @@ public class ResourcePropertyItemProvider extends ShapePropertyItemProvider {
     }
 
 	/**
+     * This adds a property descriptor for the Additional Constraints feature.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    protected void addAdditionalConstraintsPropertyDescriptor(Object object) {
+        itemPropertyDescriptors.add
+            (createItemPropertyDescriptor
+                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+                 getResourceLocator(),
+                 getString("_UI_ResourceProperty_additionalConstraints_feature"),
+                 getString("_UI_PropertyDescriptor_description", "_UI_ResourceProperty_additionalConstraints_feature", "_UI_ResourceProperty_type"),
+                 AdaptorinterfacePackage.Literals.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS,
+                 true,
+                 false,
+                 false,
+                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+                 null,
+                 null));
+    }
+
+    /**
      * This returns ResourceProperty.gif.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -392,6 +415,7 @@ public class ResourcePropertyItemProvider extends ShapePropertyItemProvider {
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__MULTI_VALUE_REPRESENTATION:
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__ALLOWED_VALUE:
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__IS_MEMBER_PROPERTY:
+            case AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS:
                 fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
                 return;
         }

--- a/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourcePropertyItemProvider.java
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/src/adaptorinterface/provider/ResourcePropertyItemProvider.java
@@ -359,7 +359,7 @@ public class ResourcePropertyItemProvider extends ShapePropertyItemProvider {
                  getString("_UI_PropertyDescriptor_description", "_UI_ResourceProperty_additionalConstraints_feature", "_UI_ResourceProperty_type"),
                  AdaptorinterfacePackage.Literals.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS,
                  true,
-                 false,
+                 true,
                  false,
                  ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
                  null,

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
@@ -1077,13 +1077,22 @@ public interface AdaptorinterfacePackage extends EPackage {
 	int RESOURCE__RESOURCE_PROPERTIES = SHAPE_FEATURE_COUNT + 6;
 
 	/**
+     * The feature id for the '<em><b>Additional Constraints</b></em>' attribute list.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     * @ordered
+     */
+    int RESOURCE__ADDITIONAL_CONSTRAINTS = SHAPE_FEATURE_COUNT + 7;
+
+    /**
      * The number of structural features of the '<em>Resource</em>' class.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      * @ordered
      */
-	int RESOURCE_FEATURE_COUNT = SHAPE_FEATURE_COUNT + 7;
+	int RESOURCE_FEATURE_COUNT = SHAPE_FEATURE_COUNT + 8;
 
 	/**
      * The number of operations of the '<em>Resource</em>' class.
@@ -3931,6 +3940,17 @@ public interface AdaptorinterfacePackage extends EPackage {
 	EReference getResource_ResourceProperties();
 
 	/**
+     * Returns the meta object for the attribute list '{@link adaptorinterface.Resource#getAdditionalConstraints <em>Additional Constraints</em>}'.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the meta object for the attribute list '<em>Additional Constraints</em>'.
+     * @see adaptorinterface.Resource#getAdditionalConstraints()
+     * @see #getResource()
+     * @generated
+     */
+    EAttribute getResource_AdditionalConstraints();
+
+    /**
      * Returns the meta object for class '{@link adaptorinterface.ResourceProperty <em>Resource Property</em>}'.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -6077,6 +6097,14 @@ public interface AdaptorinterfacePackage extends EPackage {
 		EReference RESOURCE__RESOURCE_PROPERTIES = eINSTANCE.getResource_ResourceProperties();
 
 		/**
+         * The meta object literal for the '<em><b>Additional Constraints</b></em>' attribute list feature.
+         * <!-- begin-user-doc -->
+         * <!-- end-user-doc -->
+         * @generated
+         */
+        EAttribute RESOURCE__ADDITIONAL_CONSTRAINTS = eINSTANCE.getResource_AdditionalConstraints();
+
+        /**
          * The meta object literal for the '{@link adaptorinterface.impl.ResourcePropertyImpl <em>Resource Property</em>}' class.
          * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/AdaptorinterfacePackage.java
@@ -1250,13 +1250,22 @@ public interface AdaptorinterfacePackage extends EPackage {
 	int RESOURCE_PROPERTY__IS_MEMBER_PROPERTY = SHAPE_PROPERTY_FEATURE_COUNT + 12;
 
 	/**
+     * The feature id for the '<em><b>Additional Constraints</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     * @ordered
+     */
+    int RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS = SHAPE_PROPERTY_FEATURE_COUNT + 13;
+
+    /**
      * The number of structural features of the '<em>Resource Property</em>' class.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      * @ordered
      */
-	int RESOURCE_PROPERTY_FEATURE_COUNT = SHAPE_PROPERTY_FEATURE_COUNT + 13;
+	int RESOURCE_PROPERTY_FEATURE_COUNT = SHAPE_PROPERTY_FEATURE_COUNT + 14;
 
 	/**
      * The number of operations of the '<em>Resource Property</em>' class.
@@ -4075,6 +4084,17 @@ public interface AdaptorinterfacePackage extends EPackage {
 	EAttribute getResourceProperty_IsMemberProperty();
 
 	/**
+     * Returns the meta object for the attribute '{@link adaptorinterface.ResourceProperty#getAdditionalConstraints <em>Additional Constraints</em>}'.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the meta object for the attribute '<em>Additional Constraints</em>'.
+     * @see adaptorinterface.ResourceProperty#getAdditionalConstraints()
+     * @see #getResourceProperty()
+     * @generated
+     */
+    EAttribute getResourceProperty_AdditionalConstraints();
+
+    /**
      * Returns the meta object for class '{@link adaptorinterface.CreationFactory <em>Creation Factory</em>}'.
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -6171,6 +6191,14 @@ public interface AdaptorinterfacePackage extends EPackage {
 		EAttribute RESOURCE_PROPERTY__IS_MEMBER_PROPERTY = eINSTANCE.getResourceProperty_IsMemberProperty();
 
 		/**
+         * The meta object literal for the '<em><b>Additional Constraints</b></em>' attribute feature.
+         * <!-- begin-user-doc -->
+         * <!-- end-user-doc -->
+         * @generated
+         */
+        EAttribute RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS = eINSTANCE.getResourceProperty_AdditionalConstraints();
+
+        /**
          * The meta object literal for the '{@link adaptorinterface.impl.CreationFactoryImpl <em>Creation Factory</em>}' class.
          * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Resource.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/Resource.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link adaptorinterface.Resource#getDescribes <em>Describes</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getExtends <em>Extends</em>}</li>
  *   <li>{@link adaptorinterface.Resource#getResourceProperties <em>Resource Properties</em>}</li>
+ *   <li>{@link adaptorinterface.Resource#getAdditionalConstraints <em>Additional Constraints</em>}</li>
  * </ul>
  *
  * @see adaptorinterface.AdaptorinterfacePackage#getResource()
@@ -156,6 +157,18 @@ public interface Resource extends Shape {
 	EList<ResourceProperty> getResourceProperties();
 
 	/**
+     * Returns the value of the '<em><b>Additional Constraints</b></em>' attribute list.
+     * The list contents are of type {@link java.lang.String}.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the value of the '<em>Additional Constraints</em>' attribute list.
+     * @see adaptorinterface.AdaptorinterfacePackage#getResource_AdditionalConstraints()
+     * @model
+     * @generated
+     */
+    EList<String> getAdditionalConstraints();
+
+    /**
      * Returns the value of the '<em><b>Describes</b></em>' reference.
      * <!-- begin-user-doc -->
 	 * <p>

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/ResourceProperty.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/ResourceProperty.java
@@ -26,6 +26,7 @@ import vocabulary.Property;
  *   <li>{@link adaptorinterface.ResourceProperty#getMultiValueRepresentation <em>Multi Value Representation</em>}</li>
  *   <li>{@link adaptorinterface.ResourceProperty#getAllowedValue <em>Allowed Value</em>}</li>
  *   <li>{@link adaptorinterface.ResourceProperty#getIsMemberProperty <em>Is Member Property</em>}</li>
+ *   <li>{@link adaptorinterface.ResourceProperty#getAdditionalConstraints <em>Additional Constraints</em>}</li>
  * </ul>
  *
  * @see adaptorinterface.AdaptorinterfacePackage#getResourceProperty()
@@ -368,5 +369,27 @@ public interface ResourceProperty extends ShapeProperty {
      * @generated
      */
 	void setIsMemberProperty(ResourcePropertyIsMemberProperty value);
+
+    /**
+     * Returns the value of the '<em><b>Additional Constraints</b></em>' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @return the value of the '<em>Additional Constraints</em>' attribute.
+     * @see #setAdditionalConstraints(String)
+     * @see adaptorinterface.AdaptorinterfacePackage#getResourceProperty_AdditionalConstraints()
+     * @model
+     * @generated
+     */
+    String getAdditionalConstraints();
+
+    /**
+     * Sets the value of the '{@link adaptorinterface.ResourceProperty#getAdditionalConstraints <em>Additional Constraints</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @param value the new value of the '<em>Additional Constraints</em>' attribute.
+     * @see #getAdditionalConstraints()
+     * @generated
+     */
+    void setAdditionalConstraints(String value);
 
 } // ResourceProperty

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -1470,6 +1470,16 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public EAttribute getResourceProperty_AdditionalConstraints() {
+        return (EAttribute)resourcePropertyEClass.getEStructuralFeatures().get(13);
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -2769,6 +2779,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         createEAttribute(resourcePropertyEClass, RESOURCE_PROPERTY__MULTI_VALUE_REPRESENTATION);
         createEAttribute(resourcePropertyEClass, RESOURCE_PROPERTY__ALLOWED_VALUE);
         createEAttribute(resourcePropertyEClass, RESOURCE_PROPERTY__IS_MEMBER_PROPERTY);
+        createEAttribute(resourcePropertyEClass, RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS);
 
         creationFactoryEClass = createEClass(CREATION_FACTORY);
         createEAttribute(creationFactoryEClass, CREATION_FACTORY__TITLE);
@@ -3081,6 +3092,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         initEAttribute(getResourceProperty_MultiValueRepresentation(), this.getResourcePropertyMultiValueRepresentation(), "multiValueRepresentation", "multipleTriples", 0, 1, ResourceProperty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getResourceProperty_AllowedValue(), ecorePackage.getEString(), "allowedValue", null, 0, -1, ResourceProperty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEAttribute(getResourceProperty_IsMemberProperty(), this.getResourcePropertyIsMemberProperty(), "isMemberProperty", null, 0, 1, ResourceProperty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEAttribute(getResourceProperty_AdditionalConstraints(), ecorePackage.getEString(), "additionalConstraints", null, 0, 1, ResourceProperty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         initEClass(creationFactoryEClass, CreationFactory.class, "CreationFactory", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEAttribute(getCreationFactory_Title(), ecorePackage.getEString(), "title", null, 1, 1, CreationFactory.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/AdaptorinterfacePackageImpl.java
@@ -1330,6 +1330,16 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public EAttribute getResource_AdditionalConstraints() {
+        return (EAttribute)resourceEClass.getEStructuralFeatures().get(7);
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -2764,6 +2774,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         createEReference(resourceEClass, RESOURCE__DESCRIBES);
         createEReference(resourceEClass, RESOURCE__EXTENDS);
         createEReference(resourceEClass, RESOURCE__RESOURCE_PROPERTIES);
+        createEAttribute(resourceEClass, RESOURCE__ADDITIONAL_CONSTRAINTS);
 
         resourcePropertyEClass = createEClass(RESOURCE_PROPERTY);
         createEAttribute(resourcePropertyEClass, RESOURCE_PROPERTY__ID);
@@ -3077,6 +3088,7 @@ public class AdaptorinterfacePackageImpl extends EPackageImpl implements Adaptor
         initEReference(getResource_Describes(), theVocabularyPackage.getClass_(), null, "describes", null, 0, 1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getResource_Extends(), this.getResource(), null, "extends", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         initEReference(getResource_ResourceProperties(), this.getResourceProperty(), null, "resourceProperties", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        initEAttribute(getResource_AdditionalConstraints(), ecorePackage.getEString(), "additionalConstraints", null, 0, -1, Resource.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         initEClass(resourcePropertyEClass, ResourceProperty.class, "ResourceProperty", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
         initEAttribute(getResourceProperty_Id(), ecorePackage.getEString(), "id", null, 1, 1, ResourceProperty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourceImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourceImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.EClass;
 
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EObjectResolvingEList;
 
 /**
@@ -33,6 +34,7 @@ import org.eclipse.emf.ecore.util.EObjectResolvingEList;
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getDescribes <em>Describes</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getExtends <em>Extends</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourceImpl#getResourceProperties <em>Resource Properties</em>}</li>
+ *   <li>{@link adaptorinterface.impl.ResourceImpl#getAdditionalConstraints <em>Additional Constraints</em>}</li>
  * </ul>
  *
  * @generated
@@ -149,6 +151,16 @@ public class ResourceImpl extends ShapeImpl implements Resource {
 	protected EList<ResourceProperty> resourceProperties;
 
 	/**
+     * The cached value of the '{@link #getAdditionalConstraints() <em>Additional Constraints</em>}' attribute list.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getAdditionalConstraints()
+     * @generated
+     * @ordered
+     */
+    protected EList<String> additionalConstraints;
+
+    /**
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
@@ -289,6 +301,19 @@ public class ResourceImpl extends ShapeImpl implements Resource {
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public EList<String> getAdditionalConstraints() {
+        if (additionalConstraints == null) {
+            additionalConstraints = new EDataTypeUniqueEList<String>(String.class, this, AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS);
+        }
+        return additionalConstraints;
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -350,6 +375,8 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 return getExtends();
             case AdaptorinterfacePackage.RESOURCE__RESOURCE_PROPERTIES:
                 return getResourceProperties();
+            case AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS:
+                return getAdditionalConstraints();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -386,6 +413,10 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 getResourceProperties().clear();
                 getResourceProperties().addAll((Collection<? extends ResourceProperty>)newValue);
                 return;
+            case AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS:
+                getAdditionalConstraints().clear();
+                getAdditionalConstraints().addAll((Collection<? extends String>)newValue);
+                return;
         }
         super.eSet(featureID, newValue);
     }
@@ -419,6 +450,9 @@ public class ResourceImpl extends ShapeImpl implements Resource {
             case AdaptorinterfacePackage.RESOURCE__RESOURCE_PROPERTIES:
                 getResourceProperties().clear();
                 return;
+            case AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS:
+                getAdditionalConstraints().clear();
+                return;
         }
         super.eUnset(featureID);
     }
@@ -445,6 +479,8 @@ public class ResourceImpl extends ShapeImpl implements Resource {
                 return extends_ != null && !extends_.isEmpty();
             case AdaptorinterfacePackage.RESOURCE__RESOURCE_PROPERTIES:
                 return resourceProperties != null && !resourceProperties.isEmpty();
+            case AdaptorinterfacePackage.RESOURCE__ADDITIONAL_CONSTRAINTS:
+                return additionalConstraints != null && !additionalConstraints.isEmpty();
         }
         return super.eIsSet(featureID);
     }
@@ -467,6 +503,8 @@ public class ResourceImpl extends ShapeImpl implements Resource {
         result.append(title);
         result.append(", description: ");
         result.append(description);
+        result.append(", additionalConstraints: ");
+        result.append(additionalConstraints);
         result.append(')');
         return result.toString();
     }

--- a/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourcePropertyImpl.java
+++ b/org.eclipse.lyo.tools.adaptormodel.model/src/adaptorinterface/impl/ResourcePropertyImpl.java
@@ -40,6 +40,7 @@ import vocabulary.Property;
  *   <li>{@link adaptorinterface.impl.ResourcePropertyImpl#getMultiValueRepresentation <em>Multi Value Representation</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourcePropertyImpl#getAllowedValue <em>Allowed Value</em>}</li>
  *   <li>{@link adaptorinterface.impl.ResourcePropertyImpl#getIsMemberProperty <em>Is Member Property</em>}</li>
+ *   <li>{@link adaptorinterface.impl.ResourcePropertyImpl#getAdditionalConstraints <em>Additional Constraints</em>}</li>
  * </ul>
  *
  * @generated
@@ -276,6 +277,26 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
 	protected ResourcePropertyIsMemberProperty isMemberProperty = IS_MEMBER_PROPERTY_EDEFAULT;
 
 	/**
+     * The default value of the '{@link #getAdditionalConstraints() <em>Additional Constraints</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getAdditionalConstraints()
+     * @generated
+     * @ordered
+     */
+    protected static final String ADDITIONAL_CONSTRAINTS_EDEFAULT = null;
+
+    /**
+     * The cached value of the '{@link #getAdditionalConstraints() <em>Additional Constraints</em>}' attribute.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see #getAdditionalConstraints()
+     * @generated
+     * @ordered
+     */
+    protected String additionalConstraints = ADDITIONAL_CONSTRAINTS_EDEFAULT;
+
+    /**
      * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
@@ -594,6 +615,29 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
 
 	/**
      * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public String getAdditionalConstraints() {
+        return additionalConstraints;
+    }
+
+    /**
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @generated
+     */
+    @Override
+    public void setAdditionalConstraints(String newAdditionalConstraints) {
+        String oldAdditionalConstraints = additionalConstraints;
+        additionalConstraints = newAdditionalConstraints;
+        if (eNotificationRequired())
+            eNotify(new ENotificationImpl(this, Notification.SET, AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS, oldAdditionalConstraints, additionalConstraints));
+    }
+
+    /**
+     * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
      * @generated
      */
@@ -627,6 +671,8 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
                 return getAllowedValue();
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__IS_MEMBER_PROPERTY:
                 return getIsMemberProperty();
+            case AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS:
+                return getAdditionalConstraints();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -681,6 +727,9 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__IS_MEMBER_PROPERTY:
                 setIsMemberProperty((ResourcePropertyIsMemberProperty)newValue);
                 return;
+            case AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS:
+                setAdditionalConstraints((String)newValue);
+                return;
         }
         super.eSet(featureID, newValue);
     }
@@ -732,6 +781,9 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__IS_MEMBER_PROPERTY:
                 setIsMemberProperty(IS_MEMBER_PROPERTY_EDEFAULT);
                 return;
+            case AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS:
+                setAdditionalConstraints(ADDITIONAL_CONSTRAINTS_EDEFAULT);
+                return;
         }
         super.eUnset(featureID);
     }
@@ -770,6 +822,8 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
                 return allowedValue != null && !allowedValue.isEmpty();
             case AdaptorinterfacePackage.RESOURCE_PROPERTY__IS_MEMBER_PROPERTY:
                 return isMemberProperty != IS_MEMBER_PROPERTY_EDEFAULT;
+            case AdaptorinterfacePackage.RESOURCE_PROPERTY__ADDITIONAL_CONSTRAINTS:
+                return ADDITIONAL_CONSTRAINTS_EDEFAULT == null ? additionalConstraints != null : !ADDITIONAL_CONSTRAINTS_EDEFAULT.equals(additionalConstraints);
         }
         return super.eIsSet(featureID);
     }
@@ -806,6 +860,8 @@ public class ResourcePropertyImpl extends ShapePropertyImpl implements ResourceP
         result.append(allowedValue);
         result.append(", isMemberProperty: ");
         result.append(isMemberProperty);
+        result.append(", additionalConstraints: ");
+        result.append(additionalConstraints);
         result.append(')');
         return result.toString();
     }

--- a/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
+++ b/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
@@ -2132,12 +2132,13 @@
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="title" valueExpression="var:newValue"/>
           </initialOperation>
         </controls>
+        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::ResourceProperty propertyDefinition" referenceNameExpression="aql:'propertyDefinition'"/>
         <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::ResourceProperty description" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('description')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('description'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('description').changeable" valueExpression="aql:self.description">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="description" valueExpression="var:newValue"/>
           </initialOperation>
         </controls>
-        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::ResourceProperty propertyDefinition" referenceNameExpression="aql:'propertyDefinition'"/>
+        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::ResourceProperty range" referenceNameExpression="aql:'range'"/>
         <controls xsi:type="properties:RadioDescription" name="adaptorinterface::ResourceProperty occurs" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('occurs')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('occurs'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('occurs').changeable" valueExpression="aql:self.eClass().getEStructuralFeature('occurs').eType.getEEnumLiteralByLiteral(self.occurs.toString())" candidatesExpression="aql:self.eClass().getEStructuralFeature('occurs').eType.eLiterals" candidateDisplayExpression="aql:candidate.name" numberOfColumns="5">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="occurs" valueExpression="aql:newValue.instance"/>
@@ -2153,7 +2154,6 @@
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="valueType" valueExpression="aql:newValue.instance"/>
           </initialOperation>
         </controls>
-        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::ResourceProperty range" referenceNameExpression="aql:'range'"/>
         <controls xsi:type="properties:RadioDescription" name="adaptorinterface::ResourceProperty representation" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('representation')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('representation'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('representation').changeable" valueExpression="aql:self.eClass().getEStructuralFeature('representation').eType.getEEnumLiteralByLiteral(self.representation.toString())" candidatesExpression="aql:self.eClass().getEStructuralFeature('representation').eType.eLiterals" candidateDisplayExpression="aql:candidate.name" numberOfColumns="5">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="representation" valueExpression="aql:newValue.instance"/>
@@ -2195,14 +2195,40 @@
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="title" valueExpression="var:newValue"/>
           </initialOperation>
         </controls>
+        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource describes" referenceNameExpression="aql:'describes'"/>
         <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::Resource description" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('description')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('description'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('description').changeable" valueExpression="aql:self.description">
           <initialOperation>
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="description" valueExpression="var:newValue"/>
           </initialOperation>
         </controls>
-        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource describes" referenceNameExpression="aql:'describes'"/>
-        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource extends" referenceNameExpression="aql:'extends'"/>
         <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource resourceProperties" referenceNameExpression="aql:'resourceProperties'"/>
+        <controls xsi:type="properties-ext-widgets-reference:ExtReferenceDescription" name="adaptorinterface::Resource extends" referenceNameExpression="aql:'extends'"/>
+        <controls xsi:type="properties:ListDescription" name="adaptorinterface::Resource additionalConstraints" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('additionalConstraints')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('additionalConstraints'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('additionalConstraints').changeable" valueExpression="aql:self.additionalConstraints" displayExpression="var:value">
+          <actions>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:self">
+                <subModelOperations xsi:type="properties:DialogModelOperation" titleExpression="Add Additional Constraints">
+                  <buttons labelExpression="Cancel" closeDialogOnClick="true" rollbackChangesOnClose="true">
+                    <initialOperation/>
+                  </buttons>
+                  <buttons labelExpression="OK" default="true" closeDialogOnClick="true">
+                    <initialOperation/>
+                  </buttons>
+                  <page name="adaptorinterface::Resource additionalConstraints Page" labelExpression="Page" semanticCandidateExpression="var:self" groups="//@extensions.3/@categories.0/@groups.0/@controls.6/@actions.0/@initialOperation/@firstModelOperations/@subModelOperations.0/@groups.0"/>
+                  <groups name="adaptorinterface::Resource additionalConstraints Group" labelExpression="Group" semanticCandidateExpression="var:self">
+                    <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::Resource additionalConstraints Text Area">
+                      <initialOperation>
+                        <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="var:self">
+                          <subModelOperations xsi:type="tool_1:SetValue" featureName="additionalConstraints" valueExpression="aql:newValue"/>
+                        </firstModelOperations>
+                      </initialOperation>
+                    </controls>
+                  </groups>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+          </actions>
+        </controls>
       </groups>
     </categories>
   </extensions>

--- a/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
+++ b/org.eclipse.lyo.tools.toolchain.design/description/ToolChainModel.odesign
@@ -2170,6 +2170,11 @@
             <firstModelOperations xsi:type="tool_1:SetValue" featureName="isMemberProperty" valueExpression="aql:newValue.instance"/>
           </initialOperation>
         </controls>
+        <controls xsi:type="properties:TextAreaDescription" name="adaptorinterface::ResourceProperty additionalConstraints" labelExpression="aql:input.emfEditServices(self).getText(self.eClass().getEStructuralFeature('additionalConstraints')) + ':'" helpExpression="aql:input.emfEditServices(self).getDescription(self.eClass().getEStructuralFeature('additionalConstraints'))" isEnabledExpression="aql:self.eClass().getEStructuralFeature('additionalConstraints').changeable" valueExpression="aql:self.additionalConstraints">
+          <initialOperation>
+            <firstModelOperations xsi:type="tool_1:SetValue" featureName="additionalConstraints" valueExpression="var:newValue"/>
+          </initialOperation>
+        </controls>
       </groups>
     </categories>
   </extensions>


### PR DESCRIPTION
Besides the official Description field, we need another (optional) multi-line textual field "additionalConstraints" where constraints can be specified. This can be free-text, or follow any grammar defined by specific plugins (xtext, sparql, etc.) 