### PR TITLE
Using the alaternative vocabulary namespace/prefix for a DomainSpec, when one is defined.

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorPackageInfo.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorPackageInfo.mtl
@@ -14,11 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Simple
  */
 /]
-[module generateAdaptorPackageInfo('http://org.eclipse.lyo/oslc4j/adaptorInterface')]
+[module generateAdaptorPackageInfo('http://org.eclipse.lyo/oslc4j/adaptorInterface', 'http://org.eclipse.lyo/oslc4j/vocabulary')]
 
 [import org::eclipse::lyo::oslc4j::codegenerator::services::services/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::resourceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::domainSpecificationServices/]
+[import org::eclipse::lyo::oslc4j::codegenerator::services::vocabularyServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::adaptorInterfaceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::serviceServices/]
 [import org::eclipse::lyo::oslc4j::codegenerator::services::serviceProviderServices/]
@@ -49,7 +50,8 @@
     @OslcNamespaceDefinition(prefix = OslcConstants.OSLC_DATA_NAMESPACE_PREFIX,           namespaceURI = OslcConstants.OSLC_DATA_NAMESPACE),
     @OslcNamespaceDefinition(prefix = OslcConstants.RDF_NAMESPACE_PREFIX,                 namespaceURI = OslcConstants.RDF_NAMESPACE),
     @OslcNamespaceDefinition(prefix = OslcConstants.RDFS_NAMESPACE_PREFIX,                namespaceURI = OslcConstants.RDFS_NAMESPACE),
-[for (aDomainSpecification: DomainSpecification | relevantDomainSpecifications(anAdaptorInterface)->sortedBy(name)) separator(','.concat(lineSeparator()))]    @OslcNamespaceDefinition(prefix = [javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespacePrefixConstantName(aDomainSpecification) /], namespaceURI = [javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespaceConstantName(aDomainSpecification) /])[/for]
+[for (aDomainSpecification: DomainSpecification | relevantDomainSpecifications(anAdaptorInterface)->sortedBy(name)) separator(','.concat(lineSeparator()))]    @OslcNamespaceDefinition(prefix = [javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationImplicitVocabularyNamespacePrefixConstantName(aDomainSpecification) /], namespaceURI = [javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification) /])[/for]
+[for (aVocabulary: Vocabulary | relevantVocabularies(anAdaptorInterface)->sortedBy(name)) separator(','.concat(lineSeparator()))]    @OslcNamespaceDefinition(prefix = [javaInterfaceNameForConstants(aVocabulary)/].[vocabularyPreferredNamespacePrefixConstantName(aVocabulary) /], namespaceURI = [javaInterfaceNameForConstants(aVocabulary)/].[vocabularyNamespaceConstantName(aVocabulary) /])[/for]
 })
 package [javaClassPackageNameForAdaptorPackageInfo(anAdaptorInterface) /];
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServiceProviderFactory.mtl
@@ -147,7 +147,7 @@ public class [javaClassNameForFactory(aServiceProvider) /]
             new PrefixDefinition(OslcConstants.RDF_NAMESPACE_PREFIX, new URI(OslcConstants.RDF_NAMESPACE)),
             new PrefixDefinition(OslcConstants.RDFS_NAMESPACE_PREFIX, new URI(OslcConstants.RDFS_NAMESPACE)),
             [for (aDomainSpecification: DomainSpecification | relevantDomainSpecifications(aServiceProvider)->sortedBy(name)) separator(','.concat(lineSeparator()))]
-            new PrefixDefinition([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespacePrefixConstantName(aDomainSpecification) /], new URI([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationNamespaceConstantName(aDomainSpecification) /]))
+            new PrefixDefinition([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationImplicitVocabularyNamespacePrefixConstantName(aDomainSpecification) /], new URI([javaInterfaceNameForConstants(aDomainSpecification)/].[domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification) /]))
             [/for]
         };
         serviceProvider.setPrefixDefinitions(prefixDefinitions);

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
@@ -24,9 +24,9 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::vocabularyServices/]
 
 [template public generateResourceConstants(aResource : Resource)]
-public static String [resourcePathConstantName(aResource)/] = "[javaString(aResource.name, '', false)/]";
+public static String [resourcePathConstantName(aResource)/] = "[javaString(aResource.name, '', false)/]";  //the relative path of the resource shape URL.
 public static String [resourceTypeNamespaceConstantName(aResource)/] = [resourceTypeNamespace(aResource)/]; //namespace of the rdfs:class the resource describes
-public static String [resourceTypeLocalNameConstantName(aResource)/] = "[resourceTypeLocalName(aResource)/]"; //localName of the rdfs:class the resource describes
+public static String [resourceTypeLocalNameConstantName(aResource)/] = [resourceTypeLocalName(aResource)/]; //localName of the rdfs:class the resource describes
 public static String [resourceTypeConstantName(aResource)/] = [resourceTypeNamespaceConstantName(aResource)/] + [resourceTypeLocalNameConstantName(aResource)/]; //fullname of the rdfs:class the resource describes
 [/template]
 
@@ -63,9 +63,9 @@ public interface [javaInterfaceNameForConstants(aDomainSpecification) /]
     // [protected ('user constants')]
     // [/protected]
 
-    public static String [domainSpecificationConstantName(aDomainSpecification)/] = "[aDomainSpecification.namespaceURI/]";
-    public static String [domainSpecificationNamespaceConstantName(aDomainSpecification)/] = "[aDomainSpecification.namespaceURI/]";
-    public static String [domainSpecificationNamespacePrefixConstantName(aDomainSpecification)/] = "[aDomainSpecification.namespacePrefix.name/]";
+    public static String [domainSpecificationConstantName(aDomainSpecification)/] = "[aDomainSpecification.name/]";
+    public static String [domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification)/] = "[domainSpecificationImplicitVocabularyNamespaceValue(aDomainSpecification)/]"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
+    public static String [domainSpecificationImplicitVocabularyNamespacePrefixConstantName(aDomainSpecification)/] = "[domainSpecificationImplicitVocabularyNamespacePrefixValue(aDomainSpecification)/]"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined
 
     [for (aResource: Resource | aDomainSpecification.resources->sortedBy(name))]
     [generateResourceConstants(aResource) /]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -476,7 +476,7 @@ javaFilesBasePath(anAdaptorInterface).concatenatePaths(javaInterfacePackageNameF
 
 [query public resourceTypeNamespace(aResource: Resource) : String =
 (if (aResource.describes.oclIsUndefined()) then
-    domainSpecificationNamespaceConstantName(aResource.definingDomainSpecification())
+    domainSpecificationImplicitVocabularyNamespaceConstantName(aResource.definingDomainSpecification())
 else
     javaInterfaceNameForConstants(aResource.describes.definingVocabulary()).concat('.').concat(vocabularyNamespaceConstantName(aResource.describes.definingVocabulary()))
 endif)
@@ -484,9 +484,9 @@ endif)
 
 [query public resourceTypeLocalName(aResource: Resource) : String =
 (if (aResource.describes.oclIsUndefined()) then
-    aResource.name
+    '"'.concat(aResource.name).concat('"')
 else
-    aResource.describes.name
+    javaInterfaceNameForConstants(aResource.describes.definingVocabulary()).concat('.').concat(classConstantName(aResource.describes))
 endif)
 /]
 
@@ -498,12 +498,28 @@ javaConstantString(aDomainSpecification.name)
 javaConstantName(aDomainSpecification).concat('_DOMAIN')
 /]
 
-[query public domainSpecificationNamespaceConstantName(aDomainSpecification : DomainSpecification) : String = 
+[query public domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification : DomainSpecification) : String = 
 javaConstantName(aDomainSpecification).concat('_NAMSPACE')
 /]
 
-[query public domainSpecificationNamespacePrefixConstantName(aDomainSpecification : DomainSpecification) : String = 
+[query public domainSpecificationImplicitVocabularyNamespacePrefixConstantName(aDomainSpecification : DomainSpecification) : String = 
 javaConstantName(aDomainSpecification).concat('_NAMSPACE_PREFIX')
+/]
+
+[query public domainSpecificationImplicitVocabularyNamespaceValue(aDomainSpecification : DomainSpecification) : String = 
+(if (aDomainSpecification.impliedVocabulary.oclIsUndefined()) then
+    aDomainSpecification.namespaceURI
+else
+    aDomainSpecification.impliedVocabulary.namespaceURI
+endif)
+/]
+
+[query public domainSpecificationImplicitVocabularyNamespacePrefixValue(aDomainSpecification : DomainSpecification) : String = 
+(if (aDomainSpecification.impliedVocabulary.oclIsUndefined()) then
+    aDomainSpecification.namespacePrefix.name
+else
+    aDomainSpecification.impliedVocabulary.preferredNamespacePrefix
+endif)
 /]
 
 [comment Services for RequiredAdaptor /]

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/resourcePropertyServices.mtl
@@ -35,7 +35,7 @@ not (Sequence{'URI'}->includes(aProperty.valueType.toString()))
 
 [query public resourcePropertyDefinitionNamespace(aResourceProperty: ResourceProperty) : String =
 (if (aResourceProperty.propertyDefinition.oclIsUndefined()) then
-    javaInterfaceNameForConstants(aResourceProperty.definingDomainSpecification()).concat('.').concat(domainSpecificationNamespaceConstantName(aResourceProperty.definingDomainSpecification()))
+    javaInterfaceNameForConstants(aResourceProperty.definingDomainSpecification()).concat('.').concat(domainSpecificationImplicitVocabularyNamespaceConstantName(aResourceProperty.definingDomainSpecification()))
 else
     javaInterfaceNameForConstants(aResourceProperty.propertyDefinition.definingVocabulary()).concat('.').concat(vocabularyNamespaceConstantName(aResourceProperty.propertyDefinition.definingVocabulary()))
 endif)


### PR DESCRIPTION
Using the alaternative vocabulary namespace/prefix for a DomainSpec, when one is defined.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [X] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [X] This PR does NOT break the user block code

