### PR TITLE
Fix osgi.ee=UNKNOWN capability requirement

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,5 +27,7 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+    - name: Build Lyo bundles
+      run: mvn -B -f pom.xml package -P plugins-only
+    - name: Build Lyo Designer
+      run: mvn -B -f pom.xml package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Upgraded the frontend libraries from Bootstrap v4.0.0-beta to v4.2.1.
 
 - Replaced class methods with instead methods on the ResourcesFactory class.
+- Building Lyodesigner based on Eclipse 2022-03, and the corresponding versions of Sirius and Acceleo.
 
 ### Deprecated
 

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -133,22 +133,19 @@
                                             <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
                                              Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
                                             <excludes>
-                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
-                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
                                             </excludes>
                                         </artifact>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
                                             <excludes>
-                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
-                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
                                             </excludes>
                                         </artifact>
                                         <artifact>
                                         <id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
                                             <excludes>
-                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
-                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
                                             </excludes>
                                         </artifact>
                                      </artifacts>
@@ -227,8 +224,7 @@
                                         <artifact>
                                             <id>org.eclipse.lyo.clients:oslc-client:${lyo.version}</id>
                                             <excludes>
-                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
-                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
                                             </excludes>
                                         </artifact>
                                     </artifacts>
@@ -309,13 +305,12 @@
                                             <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
                                              Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
                                             <excludes>
-                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
-                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                                 <exclude>com.google.guava:::</exclude>
                                                 <exclude>xml-apis:xml-apis::</exclude>
                                                 <exclude>com.google.errorprone:::</exclude>
                                                 <exclude>com.google.j2objc:::</exclude>
                                                 <exclude>com.google.code.findbugs:::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
                                             </excludes>
                                         </artifact>
                                      </artifacts>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -128,7 +128,8 @@
                                         Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
                                     </license>
                                     <artifacts>
-                                        <artifact><id>org.eclipse.lyo.oslc4j.core:oslc4j-core:${lyo.version}</id>
+                                        <artifact>
+                                            <id>org.eclipse.lyo.oslc4j.core:oslc4j-core:${lyo.version}</id>
                                             <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
                                              Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
                                             <excludes>
@@ -136,35 +137,37 @@
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
                                             <instructionsProperties>
-											    <property>
-											        <name>-noee</name>
-											        <value>true</value>
-											    </property>
-											</instructionsProperties>
+                                                <property>
+                                                    <name>-noee</name>
+                                                    <value>true</value>
+                                                </property>
+                                            </instructionsProperties>
                                         </artifact>
-                                        <artifact><id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
+                                        <artifact>
+                                            <id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
                                             <excludes>
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
                                             <instructionsProperties>
-											    <property>
-											        <name>-noee</name>
-											        <value>true</value>
-											    </property>
-											</instructionsProperties>
+                                                <property>
+                                                    <name>-noee</name>
+                                                    <value>true</value>
+                                                </property>
+                                            </instructionsProperties>
                                         </artifact>
-                                        <artifact><id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
+                                        <artifact>
+                                        <id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
                                             <excludes>
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
                                             <instructionsProperties>
-											    <property>
-											        <name>-noee</name>
-											        <value>true</value>
-											    </property>
-											</instructionsProperties>
+                                                <property>
+                                                    <name>-noee</name>
+                                                    <value>true</value>
+                                                </property>
+                                            </instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>
@@ -239,17 +242,18 @@
                                         Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
                                     </license>
                                     <artifacts>
-                                        <artifact><id>org.eclipse.lyo.clients:oslc-client:${lyo.version}</id>
+                                        <artifact>
+                                            <id>org.eclipse.lyo.clients:oslc-client:${lyo.version}</id>
                                             <excludes>
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
                                             <instructionsProperties>
-											    <property>
-											        <name>-noee</name>
-											        <value>true</value>
-											    </property>
-											</instructionsProperties>
+                                                <property>
+                                                    <name>-noee</name>
+                                                    <value>true</value>
+                                                </property>
+                                            </instructionsProperties>
                                         </artifact>
                                     </artifacts>
                                 </feature>
@@ -324,7 +328,8 @@
                                         Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.
                                     </license>
                                     <artifacts>
-                                        <artifact><id>org.eclipse.lyo.store:store-core:${lyo.version}</id>
+                                        <artifact>
+                                            <id>org.eclipse.lyo.store:store-core:${lyo.version}</id>
                                             <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
                                              Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
                                             <excludes>
@@ -337,11 +342,11 @@
                                                 <exclude>com.google.code.findbugs:::</exclude>
                                             </excludes>
                                             <instructionsProperties>
-											    <property>
-											        <name>-noee</name>
-											        <value>true</value>
-											    </property>
-											</instructionsProperties>
+                                                <property>
+                                                    <name>-noee</name>
+                                                    <value>true</value>
+                                                </property>
+                                            </instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -20,7 +20,7 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.1.7</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <p2.repo>http://download.eclipse.org/releases/2021-09</p2.repo>
+        <p2.repo>http://download.eclipse.org/releases/2022-03</p2.repo>
         <lyo.version>5.0.0-SNAPSHOT</lyo.version>
     </properties>
     <repositories>
@@ -136,12 +136,6 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
-                                            <instructionsProperties>
-                                                <property>
-                                                    <name>-noee</name>
-                                                    <value>true</value>
-                                                </property>
-                                            </instructionsProperties>
                                         </artifact>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
@@ -149,12 +143,6 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
-                                            <instructionsProperties>
-                                                <property>
-                                                    <name>-noee</name>
-                                                    <value>true</value>
-                                                </property>
-                                            </instructionsProperties>
                                         </artifact>
                                         <artifact>
                                         <id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
@@ -162,12 +150,6 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
-                                            <instructionsProperties>
-                                                <property>
-                                                    <name>-noee</name>
-                                                    <value>true</value>
-                                                </property>
-                                            </instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>
@@ -248,12 +230,6 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
-                                            <instructionsProperties>
-                                                <property>
-                                                    <name>-noee</name>
-                                                    <value>true</value>
-                                                </property>
-                                            </instructionsProperties>
                                         </artifact>
                                     </artifacts>
                                 </feature>
@@ -341,12 +317,6 @@
                                                 <exclude>com.google.j2objc:::</exclude>
                                                 <exclude>com.google.code.findbugs:::</exclude>
                                             </excludes>
-                                            <instructionsProperties>
-                                                <property>
-                                                    <name>-noee</name>
-                                                    <value>true</value>
-                                                </property>
-                                            </instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -20,7 +20,7 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.1.7</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <p2.repo>http://download.eclipse.org/releases/2020-12</p2.repo>
+        <p2.repo>http://download.eclipse.org/releases/2021-09</p2.repo>
         <lyo.version>5.0.0-SNAPSHOT</lyo.version>
     </properties>
     <repositories>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -20,7 +20,6 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.1.7</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <p2.repo>http://download.eclipse.org/releases/2022-03</p2.repo>
         <lyo.version>5.0.0-SNAPSHOT</lyo.version>
     </properties>
     <repositories>
@@ -130,23 +129,12 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-core:${lyo.version}</id>
-                                            <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
-                                             Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
-                                            <excludes>
-                                                <exclude>com.google.code.gson:::</exclude>
-                                            </excludes>
                                         </artifact>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
-                                            <excludes>
-                                                <exclude>com.google.code.gson:::</exclude>
-                                            </excludes>
                                         </artifact>
                                         <artifact>
-                                        <id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
-                                            <excludes>
-                                                <exclude>com.google.code.gson:::</exclude>
-                                            </excludes>
+                                        	<id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
                                         </artifact>
                                      </artifacts>
                                 </feature>
@@ -223,9 +211,6 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.clients:oslc-client:${lyo.version}</id>
-                                            <excludes>
-                                                <exclude>com.google.code.gson:::</exclude>
-                                            </excludes>
                                         </artifact>
                                     </artifacts>
                                 </feature>
@@ -302,16 +287,6 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.store:store-core:${lyo.version}</id>
-                                            <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
-                                             Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
-                                            <excludes>
-                                                <exclude>com.google.guava:::</exclude>
-                                                <exclude>xml-apis:xml-apis::</exclude>
-                                                <exclude>com.google.errorprone:::</exclude>
-                                                <exclude>com.google.j2objc:::</exclude>
-                                                <exclude>com.google.code.findbugs:::</exclude>
-                                                <exclude>com.google.code.gson:::</exclude>
-                                            </excludes>
                                         </artifact>
                                      </artifacts>
                                 </feature>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.reficio</groupId>
                 <artifactId>p2-maven-plugin</artifactId>
-                <version>1.5.0</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>
@@ -135,18 +135,36 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
+                                            <instructionsProperties>
+											    <property>
+											        <name>-noee</name>
+											        <value>true</value>
+											    </property>
+											</instructionsProperties>
                                         </artifact>
                                         <artifact><id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
                                             <excludes>
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
+                                            <instructionsProperties>
+											    <property>
+											        <name>-noee</name>
+											        <value>true</value>
+											    </property>
+											</instructionsProperties>
                                         </artifact>
                                         <artifact><id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
                                             <excludes>
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
+                                            <instructionsProperties>
+											    <property>
+											        <name>-noee</name>
+											        <value>true</value>
+											    </property>
+											</instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>
@@ -226,6 +244,12 @@
                                                 <exclude>org.apache.httpcomponents:httpcore::</exclude>
                                                 <exclude>org.apache.httpcomponents:httpclient::</exclude>
                                             </excludes>
+                                            <instructionsProperties>
+											    <property>
+											        <name>-noee</name>
+											        <value>true</value>
+											    </property>
+											</instructionsProperties>
                                         </artifact>
                                     </artifacts>
                                 </feature>
@@ -312,6 +336,12 @@
                                                 <exclude>com.google.j2objc:::</exclude>
                                                 <exclude>com.google.code.findbugs:::</exclude>
                                             </excludes>
+                                            <instructionsProperties>
+											    <property>
+											        <name>-noee</name>
+											        <value>true</value>
+											    </property>
+											</instructionsProperties>
                                         </artifact>
                                      </artifacts>
                                 </feature>

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -129,12 +129,29 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-core:${lyo.version}</id>
+                                            <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
+                                             Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
+                                            </excludes>
                                         </artifact>
                                         <artifact>
                                             <id>org.eclipse.lyo.oslc4j.core:oslc4j-jena-provider:${lyo.version}</id>
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
+                                            </excludes>
                                         </artifact>
                                         <artifact>
                                         	<id>org.eclipse.lyo.core.query:oslc-query:${lyo.version}</id>
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
+                                            </excludes>
                                         </artifact>
                                      </artifacts>
                                 </feature>
@@ -211,6 +228,11 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.clients:oslc-client:${lyo.version}</id>
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
+                                            </excludes>
                                         </artifact>
                                     </artifacts>
                                 </feature>
@@ -287,6 +309,18 @@
                                     <artifacts>
                                         <artifact>
                                             <id>org.eclipse.lyo.store:store-core:${lyo.version}</id>
+                                            <!-- 2020-09-30 Jad: We need to exclude some items, since they are already part of an eclipse installation.
+                                             Adding them might mean upgrading/downgrading these plugins, which leads to problems with other plugin installations. -->
+                                            <excludes>
+                                                <exclude>org.apache.httpcomponents:httpcore::</exclude>
+                                                <exclude>org.apache.httpcomponents:httpclient::</exclude>
+                                                <exclude>com.google.code.gson:::</exclude>
+                                                <exclude>com.google.guava:::</exclude>
+                                                <exclude>xml-apis:xml-apis::</exclude>
+                                                <exclude>com.google.errorprone:::</exclude>
+                                                <exclude>com.google.j2objc:::</exclude>
+                                                <exclude>com.google.code.findbugs:::</exclude>
+                                            </excludes>
                                         </artifact>
                                      </artifacts>
                                 </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <eclipse.cbi>1.3.2</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <p2.repo>http://download.eclipse.org/releases/2022-03</p2.repo>
-        <lyo.repo>https://download.eclipse.org/lyo/bundle/p2/edge/</lyo.repo>
+        <lyo.repo>file:org.eclipse.lyo.oslc4j.plugins/target/repository</lyo.repo>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.3.2</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <p2.repo>http://download.eclipse.org/releases/2021-09</p2.repo>
+        <p2.repo>http://download.eclipse.org/releases/2022-03</p2.repo>
         <lyo.repo>https://download.eclipse.org/lyo/bundle/p2/edge/</lyo.repo>
     </properties>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,15 @@
             </modules>
         </profile>
         <profile>
+            <id>plugins-only</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>org.eclipse.lyo.oslc4j.plugins</module>
+            </modules>
+        </profile>
+        <profile>
             <id>default</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.3.2</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <p2.repo>http://download.eclipse.org/releases/2020-12</p2.repo>
+        <p2.repo>http://download.eclipse.org/releases/2021-09</p2.repo>
         <lyo.repo>https://download.eclipse.org/lyo/bundle/p2/edge/</lyo.repo>
     </properties>
     <repositories>


### PR DESCRIPTION
## Description

p2-maven-plugin since 1.7.0 correctly detects the bytecode level using
latest JDKs again

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [x] This PR was tested with at least one code generation, resulting in a working OSLC server. **Having Acceleo problems, see below**
- [x] This PR does NOT break the user block code

## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
