### PR TITLE
ensuring "spacesForTabs" & Unix line separator is always used.

### DIFF
--- a/org.eclipse.lyo.tools.designer.branding/plugin_customization.ini
+++ b/org.eclipse.lyo.tools.designer.branding/plugin_customization.ini
@@ -2,3 +2,5 @@ org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=true
 org.eclipse.ui/DOCK_PERSPECTIVE_BAR=topRight
 org.eclipse.ui/SHOW_TRADITIONAL_STYLE_TABS=false
 org.eclipse.ui/defaultPerspectiveId=org.eclipse.sirius.ui.tools.perspective.modeling
+org.eclipse.ui.editors/spacesForTabs=true
+org.eclipse.core.runtime/line.separator=\n


### PR DESCRIPTION
## Description
ensuring "spacesForTabs" & Unix line separator is always used.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [x] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [x] This PR does NOT break the user block code

