### PR TITLE
reverting back the values of the domain names to avoid breaking old code

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateDomainSpecificationConstants.mtl
@@ -63,6 +63,11 @@ public interface [javaInterfaceNameForConstants(aDomainSpecification) /]
     // [protected ('user constants')]
     // [/protected]
 
+    /**
+     * @deprecated use {@link [javaInterfaceNameForConstants(aDomainSpecification)/]#[domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification)/]} or {@link [javaInterfaceNameForConstants(aDomainSpecification)/]#[domainSpecificationConstantName(aDomainSpecification)/]} instead
+     */
+    @Deprecated(since = "5.0.1")
+    public static String [domainSpecificationDeprecatedConstantName(aDomainSpecification)/] = "[domainSpecificationImplicitVocabularyNamespaceValue(aDomainSpecification)/]";
     public static String [domainSpecificationConstantName(aDomainSpecification)/] = "[aDomainSpecification.name/]";
     public static String [domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification)/] = "[domainSpecificationImplicitVocabularyNamespaceValue(aDomainSpecification)/]"; //Vocabulary namespace for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined 
     public static String [domainSpecificationImplicitVocabularyNamespacePrefixConstantName(aDomainSpecification)/] = "[domainSpecificationImplicitVocabularyNamespacePrefixValue(aDomainSpecification)/]"; //Vocabulary prefix for the resources and resource properties, when no explicit vocabulary (describes, or propertyDefinition) is defined

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -501,8 +501,12 @@ endif)
 javaConstantString(aDomainSpecification.name)
 /]
 
-[query public domainSpecificationConstantName(aDomainSpecification : DomainSpecification) : String = 
+[query public domainSpecificationDeprecatedConstantName(aDomainSpecification : DomainSpecification) : String = 
 javaConstantName(aDomainSpecification).concat('_DOMAIN')
+/]
+
+[query public domainSpecificationConstantName(aDomainSpecification : DomainSpecification) : String = 
+javaConstantName(aDomainSpecification).concat('_DOMAIN_Name')
 /]
 
 [query public domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification : DomainSpecification) : String = 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/adaptorInterfaceServices.mtl
@@ -506,7 +506,7 @@ javaConstantName(aDomainSpecification).concat('_DOMAIN')
 /]
 
 [query public domainSpecificationConstantName(aDomainSpecification : DomainSpecification) : String = 
-javaConstantName(aDomainSpecification).concat('_DOMAIN_Name')
+javaConstantName(aDomainSpecification).concat('_DOMAIN_NAME')
 /]
 
 [query public domainSpecificationImplicitVocabularyNamespaceConstantName(aDomainSpecification : DomainSpecification) : String = 


### PR DESCRIPTION
## description

reverting back the values of the domain names to avoid breaking old code

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [ ] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [x] This PR does NOT break the user block code

To see the results of this change, see https://github.com/eclipse/lyo/pull/285
