### PR TITLE
Switch to 6.0.0-SNAPSHOT

### DIFF
--- a/org.eclipse.lyo.oslc4j.adaptormodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.oslc4j.adaptormodel/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.oslc4j.adaptormodel;singleton:=true
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.lyo.oslc4j.codegenerator/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.oslc4j.codegenerator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Toolchain Code Generator
 Bundle-SymbolicName: org.eclipse.lyo.oslc4j.codegenerator
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: org.eclipse.lyo.oslc4j.codegenerator.Activator
 Bundle-Vendor: Eclipse Lyo
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.lyo.oslc4j.codegenerator/pom.xml
+++ b/org.eclipse.lyo.oslc4j.codegenerator/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.lyo.tools</groupId>
 		<artifactId>tools-parent</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/org.eclipse.lyo.oslc4j.plugins/pom.xml
+++ b/org.eclipse.lyo.oslc4j.plugins/pom.xml
@@ -12,7 +12,7 @@
     </parent> -->
     <groupId>org.eclipse.lyo.tools</groupId>
     <artifactId>org.eclipse.lyo.oslc4j.plugins</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <properties>
@@ -20,7 +20,7 @@
         <tycho.version>2.2.0</tycho.version>
         <eclipse.cbi>1.1.7</eclipse.cbi>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lyo.version>5.2.0-SNAPSHOT</lyo.version>
+        <lyo.version>5.1.1.Final</lyo.version>
     </properties>
     <repositories>
         <repository>

--- a/org.eclipse.lyo.tools.adaptormodel.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.adaptormodel.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.adaptormodel.edit;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.adaptormodel.edit
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: adaptorinterface.provider.AdaptorInterfaceEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.adaptormodel.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.adaptormodel.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.adaptormodel.editor;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.adaptormodel.editor
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: adaptorinterface.presentation.AdaptorInterfaceEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.adaptormodel.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.adaptormodel.model/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.adaptormodel.model;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.adaptormodel.model
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.lyo.tools.codegenerator.feature/feature.xml
+++ b/org.eclipse.lyo.tools.codegenerator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.lyo.tools.codegenerator.feature"
       label="Lyo Code Generator"
-      version="5.2.0.qualifier"
+      version="6.0.0.qualifier"
       provider-name="Eclipse Lyo">
 
    <description url="https://www.eclipse.org/lyo/">

--- a/org.eclipse.lyo.tools.codegenerator.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.codegenerator.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Acceleo Codegenerator Module IDE Plug-in
 Bundle-SymbolicName: org.eclipse.lyo.tools.codegenerator.ui;singleton:=true
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: org.eclipse.lyo.tools.codegenerator.ui.Activator
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: org.eclipse.ui,

--- a/org.eclipse.lyo.tools.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Toolchain Common
 Bundle-SymbolicName: org.eclipse.lyo.tools.common
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: org.eclipse.lyo.tools.common.Activator
 Bundle-Vendor: Eclipse Lyo
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.lyo.tools.common/pom.xml
+++ b/org.eclipse.lyo.tools.common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.lyo.tools</groupId>
 		<artifactId>tools-parent</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/org.eclipse.lyo.tools.designer.branding/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.designer.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.designer.branding;singleton:=true
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: org.eclipse.lyo.tools.designer.branding.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lyo.tools.designer.branding/pom.xml
+++ b/org.eclipse.lyo.tools.designer.branding/pom.xml
@@ -6,7 +6,7 @@
      <parent>
       <groupId>org.eclipse.lyo.tools</groupId>
       <artifactId>tools-parent</artifactId>
-      <version>5.2.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
      </parent>
      <artifactId>org.eclipse.lyo.tools.designer.branding</artifactId>

--- a/org.eclipse.lyo.tools.designer.product.feature/feature.xml
+++ b/org.eclipse.lyo.tools.designer.product.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.lyo.tools.designer.product.feature"
       label="Lyo Toolchain Designer Product Feature"
-      version="5.2.0.qualifier"
+      version="6.0.0.qualifier"
       provider-name="Eclipse Lyo">
 
    <description url="https://www.eclipse.org/lyo/">

--- a/org.eclipse.lyo.tools.designer.product/lyodesigner.product
+++ b/org.eclipse.lyo.tools.designer.product/lyodesigner.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Lyo Designer Product" uid="lyo-designer" id="org.eclipse.lyo.tools.designer.branding.product" application="org.eclipse.ui.ide.workbench" version="5.2.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Lyo Designer Product" uid="lyo-designer" id="org.eclipse.lyo.tools.designer.branding.product" application="org.eclipse.ui.ide.workbench" version="6.0.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/org.eclipse.lyo.tools.designer.product/pom.xml
+++ b/org.eclipse.lyo.tools.designer.product/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.eclipse.lyo.tools</groupId>
         <artifactId>tools-parent</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/org.eclipse.lyo.tools.preferences/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.preferences/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.lyo.tools.preferences
 Bundle-SymbolicName: org.eclipse.lyo.tools.preferences;singleton:=true
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: org.eclipse.lyo.tools.preferences.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/org.eclipse.lyo.tools.toolchain.design/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.toolchain.design/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ToolChainModel.design
 Bundle-SymbolicName: org.eclipse.lyo.tools.toolchain.design;singleton:=true
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-Activator: ToolChainModel.design.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lyo.tools.toolchain.design/pom.xml
+++ b/org.eclipse.lyo.tools.toolchain.design/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.lyo.tools</groupId>
 		<artifactId>tools-parent</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/org.eclipse.lyo.tools.toolchain.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.toolchain.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.toolchain.edit;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.toolchain.edit
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: toolchain.provider.ToolchainEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.toolchain.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.toolchain.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.toolchain.editor;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.toolchain.editor
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: toolchain.presentation.ToolchainEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.toolchain.feature/feature.xml
+++ b/org.eclipse.lyo.tools.toolchain.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.lyo.tools.toolchain.feature"
       label="Lyo Toolchain Designer"
-      version="5.2.0.qualifier"
+      version="6.0.0.qualifier"
       provider-name="Eclipse Lyo">
 
    <description url="https://www.eclipse.org/lyo/">

--- a/org.eclipse.lyo.tools.toolchain.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.toolchain.model/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.toolchain.model;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.toolchain.model
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.lyo.tools.updatesite/category.xml
+++ b/org.eclipse.lyo.tools.updatesite/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.lyo.tools.codegenerator.feature_5.2.0.qualifier.jar" id="org.eclipse.lyo.tools.codegenerator.feature" version="5.2.0.qualifier">
+   <feature url="features/org.eclipse.lyo.tools.codegenerator.feature_6.0.0.qualifier.jar" id="org.eclipse.lyo.tools.codegenerator.feature" version="6.0.0.qualifier">
       <category name="org.eclipse.lyo.tools.category"/>
    </feature>
-   <feature url="features/org.eclipse.lyo.tools.toolchain.feature_5.2.0.qualifier.jar" id="org.eclipse.lyo.tools.toolchain.feature" version="5.2.0.qualifier">
+   <feature url="features/org.eclipse.lyo.tools.toolchain.feature_6.0.0.qualifier.jar" id="org.eclipse.lyo.tools.toolchain.feature" version="6.0.0.qualifier">
       <category name="org.eclipse.lyo.tools.category"/>
    </feature>
    <category-def name="org.eclipse.lyo.tools.category" label="Lyo Toolchain Designer"/>

--- a/org.eclipse.lyo.tools.updatesite/pom.xml
+++ b/org.eclipse.lyo.tools.updatesite/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.eclipse.lyo.tools</groupId>
 		<artifactId>tools-parent</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>tools-updatesite</artifactId>

--- a/org.eclipse.lyo.tools.vocabulary.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.vocabulary.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.vocabulary.editor;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.vocabulary.editor
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: vocabulary.presentation.VocabularyEditorPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.vocabulary.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.vocabulary.model.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.vocabulary.model.edit;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.vocabulary.model.edit
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: vocabulary.provider.VocabularyEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/org.eclipse.lyo.tools.vocabulary.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.lyo.tools.vocabulary.model/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.lyo.tools.vocabulary.model;singleton:=true
 Automatic-Module-Name: org.eclipse.lyo.tools.vocabulary.model
-Bundle-Version: 5.2.0.qualifier
+Bundle-Version: 6.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.lyo.tools</groupId>
     <artifactId>tools-parent</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
## Description

Switch to 6.0.0-SNAPSHOT to match Lyo's versioning. 
Next step would be to generate code for Java 17.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [ ] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [X] This PR does NOT break the user block code

