### PR TITLE
remove uncessary javax library

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/config/generatePomXml.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/config/generatePomXml.mtl
@@ -162,11 +162,6 @@ endif)
     <scope>provided</scope>
 </dependency>
 <dependency>
-    <groupId>org.glassfish.hk2.external</groupId>
-    <artifactId>jakarta.inject</artifactId>
-    <version>2.6.1</version>
-</dependency>
-<dependency>
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-server</artifactId>
     <version>${jersey.version}</version>


### PR DESCRIPTION
## Description

remove uncessary javax library

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [x] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [x] This PR does NOT break the user block code

