### PR TITLE
Support to get LYO_BASEURL From JNDI env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - CORS support was reworked to work on all adaptor endpoints (not just Delegated UI dialogs), to support authentication correctly, and to allow CORS support be restricted to a few "CORS friend" origins.
 - Bootstrap in templates was upgraded from v4 to v5 
 - Generate for Jetty 12
+- Added JNDI environment lookup for LYO_BASEURL
 
 ### Deprecated
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServletListener.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateAdaptorServletListener.mtl
@@ -33,6 +33,9 @@ import java.util.NoSuchElementException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,6 +162,7 @@ public class [javaClassNameForAdaptorServletListener(anAdaptorInterface) /] impl
      * <ol>
      *     <li>LYO_SCHEME env variable</li>
      *     <li>%pkg_name%.scheme JVM property, e.g. org.eclipse.lyo.oslc4j.core.servlet.scheme</li>
+     *     <li>LYO_SCHEME JNDI env entry</li>
      *     <li>%pkg_name%.scheme Servlet Context parameter, e.g. org.eclipse.lyo.oslc4j.core.servlet.scheme</li>
      * </ol>
      * @param key property key name
@@ -169,8 +173,9 @@ public class [javaClassNameForAdaptorServletListener(anAdaptorInterface) /] impl
     public static String getConfigurationProperty(String key, String defaultValue, final ServletContext servletContext, Class klass) {
         String value = getConfigurationPropertyFromEnvironment(generateEnvironmentKey(key))
             .orElseGet(() -> getConfigurationPropertyFromSystemProperties(generateFullyQualifiedKey(klass, key))
-                .orElseGet(() -> getConfigurationPropertyFromContext(servletContext, generateFullyQualifiedKey(klass, key))
-                    .orElse(defaultValue)));
+                .orElseGet(() -> getConfigurationPropertyFromJndi(generateEnvironmentKey(key))
+                    .orElseGet(() -> getConfigurationPropertyFromContext(servletContext, generateFullyQualifiedKey(klass, key))
+                        .orElse(defaultValue))));
         return value;
     }
 
@@ -186,6 +191,22 @@ public class [javaClassNameForAdaptorServletListener(anAdaptorInterface) /] impl
      */
     private static String generateEnvironmentKey(String key) {
         return "LYO_" + key.toUpperCase(Locale.ROOT).replace('.', '_');
+    }
+
+    private static Optional<String> getConfigurationPropertyFromJndi(String key) {
+        try {
+            Context initCtx = new InitialContext();
+            Context envCtx = (Context) initCtx.lookup("java:comp/env");
+            Object value = envCtx.lookup(key);
+            if (value != null) {
+                logger.info("Found JNDI env entry with key {}", key);
+                return Optional.of(value.toString());
+            }
+        } catch (NamingException e) {
+            // JNDI lookup failed - normal if not running in a container or property not defined
+            logger.debug("JNDI lookup failed for key '{}': {}", key, e.getMessage());
+        }
+        return Optional.empty();
     }
 
     private static Optional<String> getConfigurationPropertyFromEnvironment(String basePathEnvKey) {


### PR DESCRIPTION
Support to get LYO_BASEURL From JNDI env variable

## Checklist

- [x] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [X] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [X] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [X] This PR does NOT break the user block code
