### PR TITLE
mtl(oauth): preserve form-encoded OAuth token  params

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateCredentialsFilter.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateCredentialsFilter.mtl
@@ -112,6 +112,27 @@ public class [anAdaptorInterface.javaClassNameForCredentialsFilter() /] implemen
     // [protected ('class_attributes')]
     // [/protected]
 
+    /**
+     * OAuthServlet obtains OAuth parameters from the Servlet parameter map. For a
+     * form-encoded token request, make the Servlet parse the entity before the
+     * JAX-RS runtime can consume it.
+     */
+    private boolean isFormEncodedOAuthTokenRequest(HttpServletRequest request) {
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+
+        String contentType = request.getContentType();
+        String formContentType = "application/x-www-form-urlencoded";
+        if (contentType == null
+                || !contentType.regionMatches(true, 0, formContentType, 0, formContentType.length())) {
+            return false;
+        }
+
+        String pathInfo = request.getPathInfo();
+        return "/oauth/requestToken".equals(pathInfo) || "/oauth/accessToken".equals(pathInfo);
+    }
+
     // [protected ('class_methods')]
     // [/protected]
 
@@ -162,6 +183,10 @@ public class [anAdaptorInterface.javaClassNameForCredentialsFilter() /] implemen
         if (servletRequest instanceof HttpServletRequest && servletResponse instanceof HttpServletResponse) {
             HttpServletRequest request = (HttpServletRequest) servletRequest;
             HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+            if (isFormEncodedOAuthTokenRequest(request)) {
+                request.getParameterMap();
+            }
 
             if (isProtectedResource(request)) {
                 [anAdaptorInterface.javaClassNameForAuthenticationApplication()/] authenticationApplication = [anAdaptorInterface.javaClassNameForAuthenticationApplication()/].getApplication();


### PR DESCRIPTION
## Description

Generated Jersey-based adaptors can reject valid OAuth 1.0 request-token and access-token POSTs when clients send signed OAuth parameters in an `application/x-www-form-urlencoded` body. Jersey may consume that body before Lyo's `OAuthServlet` reads the Servlet parameter map, causing `parameter_absent`.

This PR pre-reads the Servlet parameter map for form-encoded POST requests to `/oauth/requestToken` and `/oauth/accessToken` before dispatching to JAX-RS.

This preserves the OAuth parameters for Lyo's signature validation while
leaving the existing OAuth endpoint protection rules and login form handling
unchanged.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [x] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [x] This PR does NOT break the user block code


## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
